### PR TITLE
Add harmony gauge to health circle

### DIFF
--- a/modules/game_healthcircle/game_healthcircle.otui
+++ b/modules/game_healthcircle/game_healthcircle.otui
@@ -3,6 +3,11 @@ HealthCircle < UIProgressBar
   opacity: 0.7
   phantom: true
 
+HealthCircleExtra < UIProgressBar
+  image-source: /data/images/game/healthcircle/left_empty
+  opacity: 0.7
+  phantom: true
+
 ManaCircle < UIProgressBar
   image-source: /data/images/game/healthcircle/right_empty
   opacity: 0.7
@@ -21,6 +26,12 @@ SkillCircle < UIProgressBar
 HealthCircleFront < UIProgressBar
   image-source: /data/images/game/healthcircle/left_full
   opacity: 0.7
+  phantom: true
+
+HealthCircleExtraFront < UIProgressBar
+  image-source: /data/images/game/healthcircle/left_full
+  opacity: 0.7
+  image-color: #BE713E
   phantom: true
 
 ManaCircleFront < UIProgressBar


### PR DESCRIPTION
## Summary
- add dedicated widgets for rendering the harmony overlay in the health circle
- compute the harmony fill using player:getHarmony() with graceful fallbacks when unavailable
- keep the harmony overlay aligned during resize, opacity, and visibility updates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d83dbe8474832eb1af0c999b6abe46