### PR TITLE
Update experience tracker feed for hunting analyser

### DIFF
--- a/modules/game_analyser/classes/HuntingAnalyser.lua
+++ b/modules/game_analyser/classes/HuntingAnalyser.lua
@@ -477,11 +477,14 @@ function HuntingAnalyser:setHealingTicks(value) HuntingAnalyser.healingTicks = v
 function HuntingAnalyser:setDamageTicks(value) HuntingAnalyser.damageTicks = value end
 
 -- updaters
-function HuntingAnalyser:addRawXPGain(value) 
-	-- Calculate the actual raw XP by removing rate modifiers
-	local actualRawXP = calculateRawXP(value)
-	HuntingAnalyser.rawXPGain = HuntingAnalyser.rawXPGain + actualRawXP
-	HuntingAnalyser:updateWindow()
+function HuntingAnalyser:addRawXPGain(value, valueIsRaw)
+        if not value or value <= 0 then
+                return
+        end
+
+        local actualRawXP = valueIsRaw and value or calculateRawXP(value)
+        HuntingAnalyser.rawXPGain = HuntingAnalyser.rawXPGain + actualRawXP
+        HuntingAnalyser:updateWindow()
 end
 
 function HuntingAnalyser:addXpGain(value) 

--- a/modules/game_analyser/classes/XPAanalyser.lua
+++ b/modules/game_analyser/classes/XPAanalyser.lua
@@ -340,11 +340,14 @@ function XPAnalyser:updateNextLevel(hours, minutes)
 end
 
 -- updaters
-function XPAnalyser:addRawXPGain(value) 
-	-- Calculate the actual raw XP by removing rate modifiers
-	local actualRawXP = calculateRawXP(value)
-	XPAnalyser.rawXPGain = XPAnalyser.rawXPGain + actualRawXP
-	XPAnalyser:updateWindow()
+function XPAnalyser:addRawXPGain(value, valueIsRaw)
+        if not value or value <= 0 then
+                return
+        end
+
+        local actualRawXP = valueIsRaw and value or calculateRawXP(value)
+        XPAnalyser.rawXPGain = XPAnalyser.rawXPGain + actualRawXP
+        XPAnalyser:updateWindow()
 end
 
 function XPAnalyser:addXpGain(value) 

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -4151,8 +4151,10 @@ void ProtocolGame::parseTaskHuntingData(const InputMessagePtr& msg)
 
 void ProtocolGame::parseExperienceTracker(const InputMessagePtr& msg)
 {
-    msg->get64(); // raw exp
-    msg->get64(); // final exp
+    const uint64_t rawExp = msg->get64();
+    const uint64_t finalExp = msg->get64();
+
+    g_lua.callGlobalField("g_game", "onUpdateExperience", rawExp, finalExp);
 }
 
 void ProtocolGame::parseLootContainers(const InputMessagePtr& msg)


### PR DESCRIPTION
## Summary
- forward the experience tracker message to Lua so the analyser modules can consume it
- accumulate raw and final experience from the tracker inside the hunting analyser
- allow the hunting and XP analysers to accept already-normalized raw XP values while keeping the old fallback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8716a9878832eb5e1a08a2022a9df