### PR TITLE
Use creature helper for monk-only health circle

### DIFF
--- a/modules/game_healthcircle/game_healthcircle.lua
+++ b/modules/game_healthcircle/game_healthcircle.lua
@@ -61,6 +61,38 @@ opacityCircle = g_settings.getNumber('healthcircle_opacity', 0.35)
 monkCircleOffsetLeft = g_settings.getNumber('healthcircle_monkcircle_offset_left', 0)
 monkCircleOffsetRight = g_settings.getNumber('healthcircle_monkcircle_offset_right', -65)
 
+local function shouldShowExtraHealthCircle()
+    if not isHealthCircle then
+        return false
+    end
+
+    if not g_game.isOnline() then
+        return false
+    end
+
+    local player = g_game.getLocalPlayer()
+    if not player then
+        return false
+    end
+
+    return player:isMonk()
+end
+
+local function updateExtraHealthCircleVisibility()
+    if not healthCircleExtra or not healthCircleExtraFront or not healthCircleVirtue then
+        return
+    end
+
+    local isVisible = shouldShowExtraHealthCircle()
+    healthCircleExtra:setVisible(isVisible)
+    healthCircleExtraFront:setVisible(isVisible)
+    healthCircleVirtue:setVisible(isVisible)
+
+    if isVisible then
+        whenHarmonyChange()
+    end
+end
+
 function init()
     g_ui.importStyle("game_healthcircle.otui")
     healthCircle = g_ui.createWidget('HealthCircle', mapPanel)
@@ -103,6 +135,8 @@ function init()
         healthCircleExtra:setVisible(false)
         healthCircleExtraFront:setVisible(false)
         healthCircleVirtue:setVisible(false)
+    else
+        updateExtraHealthCircleVisibility()
     end
 
     if not isManaCircle then
@@ -236,6 +270,7 @@ function onHealthCircleGameStart()
     whenMapResizeChange()
     whenHarmonyChange()
     whenManaShieldChange()
+    updateExtraHealthCircleVisibility()
 end
 
 function whenHealthChange()
@@ -419,6 +454,7 @@ end
 
 function whenVocationChange()
     updateManaShieldDisplay()
+    updateExtraHealthCircleVisibility()
 end
 
 function whenManaChange()
@@ -668,9 +704,7 @@ function setHealthCircle(value)
     if value then
         healthCircle:setVisible(true)
         healthCircleFront:setVisible(true)
-        healthCircleExtra:setVisible(true)
-        healthCircleExtraFront:setVisible(true)
-        healthCircleVirtue:setVisible(true)
+        updateExtraHealthCircleVisibility()
         whenMapResizeChange()
     else
         healthCircle:setVisible(false)

--- a/modules/game_healthcircle/game_healthcircle.lua
+++ b/modules/game_healthcircle/game_healthcircle.lua
@@ -61,6 +61,22 @@ opacityCircle = g_settings.getNumber('healthcircle_opacity', 0.35)
 monkCircleOffsetLeft = g_settings.getNumber('healthcircle_monkcircle_offset_left', 0)
 monkCircleOffsetRight = g_settings.getNumber('healthcircle_monkcircle_offset_right', -65)
 
+local function isMonkVocation(player)
+    local ok, result = pcall(player.isMonk, player)
+    if ok then
+        return result == true
+    end
+
+    local vocationName = player:getVocationName()
+    if type(vocationName) == 'string' then
+        local normalized = vocationName:upper()
+        return normalized == 'MONK' or normalized == 'EXALTED MONK'
+    end
+
+    g_logger.warning(string.format('Failed to determine monk vocation: %s', tostring(result)))
+    return false
+end
+
 local function shouldShowExtraHealthCircle()
     if not isHealthCircle then
         return false
@@ -75,7 +91,7 @@ local function shouldShowExtraHealthCircle()
         return false
     end
 
-    return player:isMonk()
+    return isMonkVocation(player)
 end
 
 local function updateExtraHealthCircleVisibility()


### PR DESCRIPTION
## Summary
- rely on the creature `isMonk` helper when deciding if the extra health circle should be visible

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d98eaafc90832ea0f48bef61b1a1e0