### PR TITLE
Reset prey interface on logout

### DIFF
--- a/modules/game_prey/prey.lua
+++ b/modules/game_prey/prey.lua
@@ -58,7 +58,7 @@ end
 function init()
     connect(g_game, {
         onGameStart = check,
-        onGameEnd = hide,
+        onGameEnd = onGameEnd,
         onResourcesBalanceChange = Prey.onResourcesBalanceChange,
         onPreyFreeRerolls = onPreyFreeRerolls,
         onPreyTimeLeft = onPreyTimeLeft,
@@ -171,7 +171,7 @@ end
 function terminate()
     disconnect(g_game, {
         onGameStart = check,
-        onGameEnd = hide,
+        onGameEnd = onGameEnd,
         onResourcesBalanceChange = Prey.onResourcesBalanceChange,
         onPreyFreeRerolls = onPreyFreeRerolls,
         onPreyTimeLeft = onPreyTimeLeft,
@@ -268,6 +268,54 @@ function toggle()
         return hide()
     end
     show()
+end
+
+local function resetPreyWindowState()
+    if not preyWindow then
+        return
+    end
+
+    preyWindow.description:setText('')
+    preyWindow.gold:setText('0')
+    preyWindow.wildCards:setText('0')
+
+    for slot = 0, 2 do
+        onPreyInactive(slot, 0, 0)
+
+        local prey = preyWindow['slot' .. (slot + 1)]
+        if prey then
+            if prey.title then
+                prey.title:setText('')
+            end
+
+            if prey.inactive and prey.inactive.list then
+                prey.inactive.list:destroyChildren()
+            end
+
+            if prey.active and prey.active.creatureAndBonus then
+                local creatureAndBonus = prey.active.creatureAndBonus
+                if creatureAndBonus.timeLeft then
+                    creatureAndBonus.timeLeft:setPercent(0)
+                    creatureAndBonus.timeLeft:setText('')
+                end
+
+                if creatureAndBonus.bonus and creatureAndBonus.bonus.grade then
+                    creatureAndBonus.bonus.grade:destroyChildren()
+                end
+            end
+        end
+    end
+
+    preyDescription = {}
+    rerollPrice = 0
+    bonusRerolls = 0
+    bankGold = 0
+    inventoryGold = 0
+end
+
+function onGameEnd()
+    resetPreyWindowState()
+    hide()
 end
 
 function onMiniWindowOpen()


### PR DESCRIPTION
## Summary
- reset the prey window when the game session ends so stale data is not shown on the next login
- clear slot titles, progress information, and cached descriptions while returning each slot to the inactive state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd3e9389e0832eaeb5ea897ff85434