### PR TITLE
Truncate prey selection title text

### DIFF
--- a/modules/game_prey/prey.lua
+++ b/modules/game_prey/prey.lua
@@ -746,7 +746,8 @@ updateRaceSelectionDisplay = function(slot)
 
     if fullList.selectionTitle then
         if entry then
-            fullList.selectionTitle:setText(tr('Selected: %s', entry.name))
+            local formattedName = formatCreatureListText(entry.name)
+            fullList.selectionTitle:setText(tr('Selected: %s', formattedName))
         else
             fullList.selectionTitle:setText(tr('Select your prey creature'))
         end

--- a/modules/game_prey/prey.lua
+++ b/modules/game_prey/prey.lua
@@ -683,8 +683,10 @@ local function formatCreatureListText(name)
         return ''
     end
 
-    if #name > 19 then
-        return name:sub(1, 16) .. '...'
+    local maxLength = 16
+
+    if #name > maxLength then
+        return name:sub(1, maxLength) .. '...'
     end
 
     return name


### PR DESCRIPTION
## Summary
- ensure the prey selection header truncates long creature names with an ellipsis to keep the layout aligned

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd75259ef8832e8fba71380d50d980