### PR TITLE
Refine prey selection header styling

### DIFF
--- a/modules/game_prey/prey.lua
+++ b/modules/game_prey/prey.lua
@@ -791,8 +791,20 @@ updateRaceSelectionDisplay = function(slot)
             setWidgetTextToFit(fullList.selectionTitle, entry.name, function(value)
                 return tr('Selected: %s', value)
             end)
+            fullList.selectionTitle:setColor('#f0f0f0')
         else
             fullList.selectionTitle:setText(tr('Select your prey creature'))
+            fullList.selectionTitle:setColor('#cfcfcf')
+        end
+    end
+
+    if fullList.selectionHeader then
+        if entry then
+            fullList.selectionHeader:setBackgroundColor('#2b2b2b')
+            fullList.selectionHeader:setBorderColor('#3d3d3d')
+        else
+            fullList.selectionHeader:setBackgroundColor('#1f1f1f')
+            fullList.selectionHeader:setBorderColor('#2f2f2f')
         end
     end
 

--- a/modules/game_prey/prey.otui
+++ b/modules/game_prey/prey.otui
@@ -376,14 +376,28 @@ InactivePreyPanel < Panel
     image-source: /images/ui/panel_flat
     image-border: 1
 
-    Label
-      id: selectionTitle
+    FlatPanel
+      id: selectionHeader
       anchors.left: parent.left
       anchors.right: parent.right
       anchors.top: parent.top
-      text-align: center
-      font: verdana-11px-rounded
-      text: tr('Select your prey creature')
+      height: 28
+      padding-left: 6
+      padding-right: 6
+      padding-top: 4
+      padding-bottom: 4
+      margin-bottom: 4
+      background-color: #1f1f1f
+      border-color: #2f2f2f
+      border-width: 1
+
+      Label
+        id: selectionTitle
+        anchors.fill: parent
+        text-align: center
+        font: verdana-11px-rounded
+        text: tr('Select your prey creature')
+        color: #cfcfcf
 
     UIScrollArea
       id: entries


### PR DESCRIPTION
## Summary
- wrap the prey selection title with a styled header panel to match the desired layout
- adjust the header and title colors dynamically based on whether a creature is selected

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dd7aaaa3f8832e9ad9b4b43e42370e