### PR TITLE
Adjust prey active panel layout

### DIFF
--- a/modules/game_prey/prey.lua
+++ b/modules/game_prey/prey.lua
@@ -215,11 +215,19 @@ function setUnsupportedSettings()
     for i, slot in pairs(t) do
         local panel = preyWindow[slot]
         for j, state in pairs({panel.active, panel.inactive}) do
-            state.select.price.text:setText('-------')
+            if state.select and state.select.price then
+                state.select.price.text:setText('-------')
+            end
         end
-        panel.active.autoRerollPrice.text:setText('1')
-        panel.active.lockPreyPrice.text:setText('5')
-        panel.active.choose.price.text:setText(1)
+        if panel.active.autoRerollPrice then
+            panel.active.autoRerollPrice.text:setText('1')
+        end
+        if panel.active.lockPreyPrice then
+            panel.active.lockPreyPrice.text:setText('5')
+        end
+        if panel.active.choose and panel.active.choose.price then
+            panel.active.choose.price:setText(1)
+        end
     end
 end
 
@@ -1051,6 +1059,9 @@ end
 local suppressOptionCheckHandler = false
 
 local function setOptionCheckedSilently(checkbox, checked)
+    if not checkbox then
+        return
+    end
     if checkbox:isChecked() == checked then
         return
     end
@@ -1076,6 +1087,9 @@ local function sendOption(slot, option)
 end
 
 local function handleToggleOptions(checkbox, slot, currentOption, checked)
+    if not checkbox then
+        return
+    end
     if suppressOptionCheckHandler then
         return
     end
@@ -1192,23 +1206,33 @@ function onPreyActive(slot, currentHolderName, currentHolderOutfit, bonusType, b
     setBonusGradeStars(slot, bonusGrade)
     creatureAndBonus.timeLeft:setPercent(percent)
     creatureAndBonus.timeLeft:setText(timeleftTranslation(timeLeft))
-    -- bonus reroll
-    prey.active.choose.selectPrey.onClick = function()
-        g_game.preyAction(slot, PREY_ACTION_BONUSREROLL, 0)
-    end
-    -- creature reroll
-    prey.active.reroll.button.rerollButton.onClick = function()
-        g_game.preyAction(slot, PREY_ACTION_LISTREROLL, 0)
+
+    if prey.active.choose and prey.active.choose.selectPrey then
+        prey.active.choose.selectPrey.onClick = function()
+            g_game.preyAction(slot, PREY_ACTION_BONUSREROLL, 0)
+        end
     end
 
-    setOptionCheckedSilently(prey.active.autoReroll.autoRerollCheck, option == PREY_ACTION_BONUSREROLL)
-    prey.active.autoReroll.autoRerollCheck.onCheckChange = function(widget, checked)
-        handleToggleOptions(widget, slot, PREY_OPTION_TOGGLE_AUTOREROLL, checked)
+    if prey.active.reroll and prey.active.reroll.button and prey.active.reroll.button.rerollButton then
+        prey.active.reroll.button.rerollButton.onClick = function()
+            g_game.preyAction(slot, PREY_ACTION_LISTREROLL, 0)
+        end
     end
 
-    setOptionCheckedSilently(prey.active.lockPrey.lockPreyCheck, option == PREY_OPTION_TOGGLE_LOCK_PREY)
-    prey.active.lockPrey.lockPreyCheck.onCheckChange = function(widget, checked)
-        handleToggleOptions(widget, slot, PREY_OPTION_TOGGLE_LOCK_PREY, checked)
+    local autoRerollCheck = prey.active.autoReroll and prey.active.autoReroll.autoRerollCheck
+    if autoRerollCheck then
+        setOptionCheckedSilently(autoRerollCheck, option == PREY_ACTION_BONUSREROLL)
+        autoRerollCheck.onCheckChange = function(widget, checked)
+            handleToggleOptions(widget, slot, PREY_OPTION_TOGGLE_AUTOREROLL, checked)
+        end
+    end
+
+    local lockPreyCheck = prey.active.lockPrey and prey.active.lockPrey.lockPreyCheck
+    if lockPreyCheck then
+        setOptionCheckedSilently(lockPreyCheck, option == PREY_OPTION_TOGGLE_LOCK_PREY)
+        lockPreyCheck.onCheckChange = function(widget, checked)
+            handleToggleOptions(widget, slot, PREY_OPTION_TOGGLE_LOCK_PREY, checked)
+        end
     end
 end
 

--- a/modules/game_prey/prey.otui
+++ b/modules/game_prey/prey.otui
@@ -171,100 +171,21 @@ ActivePreyPanel < Panel
   CreatureAndBonus
     id: creatureAndBonus
     anchors.left: parent.left
+    anchors.right: parent.right
     anchors.top: parent.top
+    anchors.bottom: parent.bottom
     margin-top: 20
-
-  BonusReroll
-    id: choose
-    anchors.right: parent.right
-    anchors.top: prev.bottom
-
-  SelectPreyCreature
-    id: select
-    anchors.verticalCenter: prev.verticalCenter
-    anchors.right: prev.left
-    margin-right: 2
-
-  RerollButton
-    id: reroll
-    anchors.verticalCenter: prev.verticalCenter
-    anchors.right: prev.left
-    margin-right: 2
-
-  FlatPanel
-    id: autoReroll
-    size: 160 20
-    anchors.top: prev.bottom
-    margin-top: 5
-    anchors.left: parent.left
-
-    CheckBox
-      id: autoRerollCheck
-      margin-top: 2
-      anchors.verticalCenter: parent.verticalCenter
-      anchors.left: parent.left
-      anchors.right: parent.right
-      size: 155 15
-      font: verdana-11px-rounded
-      text: Automatic Bonus Rer...
-      margin-left: 5
-      text-offset: 20 1
-
-  CardLabel
-    id: autoRerollPrice
-    anchors.top: prev.top
-    anchors.left: prev.right
-    margin-left: 2
-    anchors.bottom: prev.bottom
-    anchors.right: parent.right
-
-  FlatPanel
-    id: lockPrey
-    size: 160 20
-    anchors.top: prev.bottom
-    margin-top: 5
-    anchors.left: parent.left
-
-    CheckBox
-      id: lockPreyCheck
-      margin-top: 2
-      anchors.verticalCenter: parent.verticalCenter
-      anchors.left: parent.left
-      anchors.right: parent.right
-      size: 155 15
-      font: verdana-11px-rounded
-      text: Lock Prey
-      margin-left: 5
-      text-offset: 20 1
-
-  CardLabel
-    id: lockPreyPrice
-    anchors.top: prev.top
-    anchors.left: prev.right
-    margin-left: 2
-    anchors.bottom: prev.bottom
-    anchors.right: parent.right
+    margin-bottom: 10
 
 CreatureAndBonus < Panel
   size: 195 152
 
-  UICreature
-    id: creature
-    phantom: true
-    anchors.top: parent.top
-    anchors.left: parent.left
-    size: 124 124
-    image-source: /images/ui/panel_flat
-    image-border: 1
-    padding: 5
-
   FlatPanel
     id: bonus
     anchors.top: parent.top
-    anchors.left: prev.right
-    margin-left: 10
-    anchors.bottom: prev.bottom
+    anchors.left: parent.left
     anchors.right: parent.right
+    height: 120
 
     UIWidget
       id: icon
@@ -303,6 +224,18 @@ CreatureAndBonus < Panel
     anchors.right: parent.right
     height: 20
     background-color: #C28400
+
+  UICreature
+    id: creature
+    phantom: true
+    anchors.top: prev.bottom
+    anchors.horizontalCenter: parent.horizontalCenter
+    anchors.bottom: parent.bottom
+    margin-top: 10
+    size: 124 124
+    image-source: /images/ui/panel_flat
+    image-border: 1
+    padding: 5
 
 BonusReroll < FlatPanel
   padding: 2


### PR DESCRIPTION
## Summary
- remove the bonus reroll card controls from the active prey panel
- expand the creature preview panel to occupy the freed space
- guard Lua logic that referenced the removed widgets so the dialog remains stable

## Testing
- ⚠️ `luac -p modules/game_prey/prey.lua` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd80a2eb1c832eaed975cd75a22bd4