### PR TITLE
Adjust prey list selection layout

### DIFF
--- a/modules/game_prey/prey.lua
+++ b/modules/game_prey/prey.lua
@@ -296,6 +296,11 @@ local function restoreListSelectionLayout(prey)
             end
             priceLabel.__listSelectionStoredText = nil
         end
+
+        if selectPanel.pickSpecificPrey and selectPanel.pickSpecificPrey.__listSelectionStoredVisibility ~= nil and selectPanel.pickSpecificPrey.setVisible then
+            selectPanel.pickSpecificPrey:setVisible(selectPanel.pickSpecificPrey.__listSelectionStoredVisibility)
+            selectPanel.pickSpecificPrey.__listSelectionStoredVisibility = nil
+        end
     end
 
     local fullList = inactive.fullList
@@ -383,6 +388,15 @@ local function applyListSelectionLayout(prey)
                 priceLabel:setText('')
             end
         end
+
+        if selectPanel.pickSpecificPrey then
+            if selectPanel.pickSpecificPrey.setVisible and selectPanel.pickSpecificPrey.__listSelectionStoredVisibility == nil then
+                selectPanel.pickSpecificPrey.__listSelectionStoredVisibility = selectPanel.pickSpecificPrey:isVisible()
+            end
+            if selectPanel.pickSpecificPrey.setVisible then
+                selectPanel.pickSpecificPrey:setVisible(false)
+            end
+        end
     end
 
     local fullList = inactive.fullList
@@ -401,16 +415,18 @@ local function applyListSelectionLayout(prey)
     preview:removeAnchor(AnchorBottom)
     preview:removeAnchor(AnchorTop)
 
-    local anchorTarget = reroll and reroll:getId()
+    local anchorWidget = selectPanel or reroll
+    local anchorTarget = anchorWidget and anchorWidget:getId()
     if anchorTarget and anchorTarget ~= '' then
         preview:addAnchor(AnchorLeft, anchorTarget, AnchorLeft)
         preview:addAnchor(AnchorRight, anchorTarget, AnchorRight)
+        preview:addAnchor(AnchorTop, anchorTarget, AnchorTop)
         preview:addAnchor(AnchorBottom, anchorTarget, AnchorBottom)
-        if reroll.getWidth then
-            preview:setWidth(reroll:getWidth())
+        if anchorWidget.getWidth then
+            preview:setWidth(anchorWidget:getWidth())
         end
-        if preview.__listSelectionDefaults and preview.__listSelectionDefaults.height then
-            preview:setHeight(preview.__listSelectionDefaults.height)
+        if anchorWidget.getHeight then
+            preview:setHeight(anchorWidget:getHeight())
         end
     else
         local parentWidget = preview:getParent()

--- a/modules/game_prey/prey.lua
+++ b/modules/game_prey/prey.lua
@@ -418,13 +418,12 @@ local function applyListSelectionLayout(prey)
     local anchorWidget = selectPanel or reroll
     local anchorTarget = anchorWidget and anchorWidget:getId()
     if anchorTarget and anchorTarget ~= '' then
-        preview:addAnchor(AnchorLeft, anchorTarget, AnchorLeft)
-        preview:addAnchor(AnchorRight, anchorTarget, AnchorRight)
+        local parentWidget = preview:getParent()
+        local parentId = parentWidget and parentWidget:getId() or 'parent'
+        preview:addAnchor(AnchorLeft, parentId, AnchorLeft)
+        preview:addAnchor(AnchorRight, parentId, AnchorRight)
         preview:addAnchor(AnchorTop, anchorTarget, AnchorTop)
         preview:addAnchor(AnchorBottom, anchorTarget, AnchorBottom)
-        if anchorWidget.getWidth then
-            preview:setWidth(anchorWidget:getWidth())
-        end
         if anchorWidget.getHeight then
             preview:setHeight(anchorWidget:getHeight())
         end
@@ -443,6 +442,7 @@ local function applyListSelectionLayout(prey)
     preview:setMarginBottom(0)
     preview:setMarginLeft(0)
     preview:setMarginRight(0)
+    preview:raise()
 
     if fullList.searchClearButton then
         if fullList.searchClearButton.__listSelectionStoredVisibility == nil then

--- a/modules/game_prey/prey.lua
+++ b/modules/game_prey/prey.lua
@@ -340,6 +340,16 @@ local function restoreListSelectionLayout(prey)
     end
 
     preview.__listSelectionLayout = nil
+
+    if fullList.searchClearButton then
+        if fullList.searchClearButton.__listSelectionStoredVisibility ~= nil then
+            fullList.searchClearButton:setVisible(fullList.searchClearButton.__listSelectionStoredVisibility)
+            fullList.searchClearButton.__listSelectionStoredVisibility = nil
+        else
+            fullList.searchClearButton:setVisible(true)
+        end
+        fullList.searchClearButton.__listSelectionForceHidden = nil
+    end
 end
 
 local function applyListSelectionLayout(prey)
@@ -395,13 +405,12 @@ local function applyListSelectionLayout(prey)
     if anchorTarget and anchorTarget ~= '' then
         preview:addAnchor(AnchorLeft, anchorTarget, AnchorLeft)
         preview:addAnchor(AnchorRight, anchorTarget, AnchorRight)
-        preview:addAnchor(AnchorTop, anchorTarget, AnchorTop)
         preview:addAnchor(AnchorBottom, anchorTarget, AnchorBottom)
         if reroll.getWidth then
             preview:setWidth(reroll:getWidth())
         end
-        if reroll.getHeight then
-            preview:setHeight(reroll:getHeight())
+        if preview.__listSelectionDefaults and preview.__listSelectionDefaults.height then
+            preview:setHeight(preview.__listSelectionDefaults.height)
         end
     else
         local parentWidget = preview:getParent()
@@ -409,12 +418,23 @@ local function applyListSelectionLayout(prey)
         preview:addAnchor(AnchorLeft, parentId, AnchorLeft)
         preview:addAnchor(AnchorRight, parentId, AnchorRight)
         preview:addAnchor(AnchorBottom, parentId, AnchorBottom)
+        if preview.__listSelectionDefaults and preview.__listSelectionDefaults.height then
+            preview:setHeight(preview.__listSelectionDefaults.height)
+        end
     end
 
     preview:setMarginTop(0)
     preview:setMarginBottom(0)
     preview:setMarginLeft(0)
     preview:setMarginRight(0)
+
+    if fullList.searchClearButton then
+        if fullList.searchClearButton.__listSelectionStoredVisibility == nil then
+            fullList.searchClearButton.__listSelectionStoredVisibility = fullList.searchClearButton:isVisible()
+        end
+        fullList.searchClearButton:setVisible(false)
+        fullList.searchClearButton.__listSelectionForceHidden = true
+    end
 
     preview.__listSelectionLayout = true
 end
@@ -826,6 +846,11 @@ local function updateRaceSearchClearButton(slot)
     local fullList = prey.inactive.fullList
     local clearButton = fullList.searchClearButton
     if not clearButton then
+        return
+    end
+
+    if clearButton.__listSelectionForceHidden then
+        clearButton:setVisible(false)
         return
     end
 

--- a/modules/game_prey/prey.otui
+++ b/modules/game_prey/prey.otui
@@ -452,6 +452,7 @@ InactivePreyPanel < Panel
         anchors.centerIn: parent
         font: verdana-11px-rounded
         text-align: center
+        text-wrap: true
         !text: tr('No creature selected')
         color: #cfcfcf
 


### PR DESCRIPTION
## Summary
- hide the reroll controls when the prey dialog enters list selection mode and preserve the previous layout when leaving it
- move the monster preview into the freed space while restoring the default anchors outside list selection
- allow the placeholder text to wrap so it fits inside the reduced preview panel

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dd855e4040832eb2f81ebc548d0d82