### PR TITLE
Fix prey option toggle handling

### DIFF
--- a/modules/game_prey/prey.lua
+++ b/modules/game_prey/prey.lua
@@ -1476,11 +1476,11 @@ local function handleToggleOptions(checkbox, slot, currentOption, checked)
         local function confirm()
             if otherCheckbox and otherCheckbox:isChecked() then
                 setOptionCheckedSilently(otherCheckbox, false)
-                sendOption(PREY_OPTION_UNTOGGLE)
+                sendOption(slot, PREY_OPTION_UNTOGGLE)
             end
 
             setOptionCheckedSilently(checkbox, true)
-            sendOption(currentOption)
+            sendOption(slot, currentOption)
             closeWindow()
         end
 
@@ -1510,7 +1510,7 @@ local function handleToggleOptions(checkbox, slot, currentOption, checked)
         return
     end
 
-    sendOption(PREY_OPTION_UNTOGGLE)
+    sendOption(slot, PREY_OPTION_UNTOGGLE)
 end
 
 function onPreyActive(slot, currentHolderName, currentHolderOutfit, bonusType, bonusValue, bonusGrade, timeLeft,


### PR DESCRIPTION
## Summary
- ensure prey option toggles send their actions with the slot information
- keep mutually exclusive prey options in sync when confirming toggles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddd6ee0d44832ea950239194a8a962