### PR TITLE
Disable hover feedback on prey name entries

### DIFF
--- a/modules/game_prey/prey.lua
+++ b/modules/game_prey/prey.lua
@@ -1430,12 +1430,10 @@ refreshRaceList = function(slot)
             item.preySlot = slot
             item.baseBackground = useAlternate and backgroundB or backgroundA
             item.checkedBackground = '#585858'
-            item.baseBorderColor = 'alpha'
             item.checkedBorderColor = '#6fb1e9ff'
             item.baseTextColor = '#c0c0c0'
             item.checkedTextColor = '#ffffff'
             item:setBackgroundColor(item.baseBackground)
-            item:setBorderColor(item.baseBorderColor)
             item:setColor(item.baseTextColor)
             item.onCheckChange = function(widget)
                 restoreRaceListItemBackground(widget)

--- a/modules/game_prey/prey.lua
+++ b/modules/game_prey/prey.lua
@@ -37,6 +37,7 @@ local refreshRaceList
 local setRaceSelection
 local updateRaceSelectionDisplay
 local restoreRaceListItemBackground
+local setWidgetTreePhantom
 local updatePickSpecificPreyButton
 local refreshRerollButtonState
 
@@ -985,6 +986,18 @@ function resetPreyPreviewWidget(preview)
     end
 end
 
+setWidgetTreePhantom = function(widget, phantom)
+    if not widget or widget:isDestroyed() then
+        return
+    end
+
+    widget:setPhantom(phantom)
+
+    for _, child in pairs(widget:getChildren()) do
+        setWidgetTreePhantom(child, phantom)
+    end
+end
+
 function setInactiveMode(slot, showFullList, prey)
     prey = prey or getPreySlotWidget(slot)
     if not prey or not prey.inactive then
@@ -995,6 +1008,7 @@ function setInactiveMode(slot, showFullList, prey)
 
     if inactive.list then
         inactive.list:setVisible(not showFullList)
+        setWidgetTreePhantom(inactive.list, showFullList)
     end
 
     if inactive.fullList then

--- a/modules/game_prey/prey.lua
+++ b/modules/game_prey/prey.lua
@@ -1264,11 +1264,23 @@ restoreRaceListItemBackground = function(widget)
         if widget.checkedBackground then
             widget:setBackgroundColor(widget.checkedBackground)
         end
+        if widget.checkedBorderColor then
+            widget:setBorderColor(widget.checkedBorderColor)
+        end
+        if widget.checkedTextColor then
+            widget:setColor(widget.checkedTextColor)
+        end
         return
     end
 
     if widget.baseBackground then
         widget:setBackgroundColor(widget.baseBackground)
+    end
+    if widget.baseBorderColor then
+        widget:setBorderColor(widget.baseBorderColor)
+    end
+    if widget.baseTextColor then
+        widget:setColor(widget.baseTextColor)
     end
 end
 
@@ -1404,7 +1416,13 @@ refreshRaceList = function(slot)
             item.preySlot = slot
             item.baseBackground = useAlternate and backgroundB or backgroundA
             item.checkedBackground = '#585858'
+            item.baseBorderColor = 'alpha'
+            item.checkedBorderColor = '#6fb1e9ff'
+            item.baseTextColor = '#c0c0c0'
+            item.checkedTextColor = '#ffffff'
             item:setBackgroundColor(item.baseBackground)
+            item:setBorderColor(item.baseBorderColor)
+            item:setColor(item.baseTextColor)
             item.onCheckChange = function(widget)
                 restoreRaceListItemBackground(widget)
             end
@@ -1489,6 +1507,14 @@ function onPreyRaceListItemClicked(widget)
         return
     end
     setRaceSelection(widget.preySlot, widget, false)
+end
+
+function onPreyRaceListItemHoverChange(widget, hovered)
+    if not widget or widget:isDestroyed() then
+        return
+    end
+
+    restoreRaceListItemBackground(widget)
 end
 
 local suppressOptionCheckHandler = false

--- a/modules/game_prey/prey.lua
+++ b/modules/game_prey/prey.lua
@@ -1278,9 +1278,6 @@ restoreRaceListItemBackground = function(widget)
         if widget.checkedBackground then
             widget:setBackgroundColor(widget.checkedBackground)
         end
-        if widget.checkedBorderColor then
-            widget:setBorderColor(widget.checkedBorderColor)
-        end
         if widget.checkedTextColor then
             widget:setColor(widget.checkedTextColor)
         end
@@ -1289,9 +1286,6 @@ restoreRaceListItemBackground = function(widget)
 
     if widget.baseBackground then
         widget:setBackgroundColor(widget.baseBackground)
-    end
-    if widget.baseBorderColor then
-        widget:setBorderColor(widget.baseBorderColor)
     end
     if widget.baseTextColor then
         widget:setColor(widget.baseTextColor)
@@ -1430,7 +1424,6 @@ refreshRaceList = function(slot)
             item.preySlot = slot
             item.baseBackground = useAlternate and backgroundB or backgroundA
             item.checkedBackground = '#585858'
-            item.checkedBorderColor = '#6fb1e9ff'
             item.baseTextColor = '#c0c0c0'
             item.checkedTextColor = '#ffffff'
             item:setBackgroundColor(item.baseBackground)

--- a/modules/game_prey/prey.otui
+++ b/modules/game_prey/prey.otui
@@ -607,6 +607,7 @@ PreyCreatureListItem < UICheckBox
   text-offset: 4 0
   size-policy-horizontal: expanding
   @onClick: modules.game_prey.onPreyRaceListItemClicked(self)
+  @onHoverChange: modules.game_prey.onPreyRaceListItemHoverChange(self)
 
   $checked on:
     background-color: #1c4d75ff


### PR DESCRIPTION
## Summary
- keep prey creature list entries using their base colors even when hovered
- add a dedicated hover change handler for name list items so only outfit entries react to hover

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68dec27d4484832ea886991bc6aaeef8