### PR TITLE
Implement forge history pagination UI

### DIFF
--- a/modules/game_forge/game_forge.lua
+++ b/modules/game_forge/game_forge.lua
@@ -93,26 +93,6 @@ local historyActionLabels = {
     [4] = tr('Conversion')
 }
 
-local function measureWidgetContentWidth(widget)
-    if not widget or widget:isDestroyed() then
-        return 0
-    end
-
-    local width = 0
-    if widget.getTextSize then
-        local textSize = widget:getTextSize()
-        if textSize and textSize.width then
-            width = textSize.width
-        end
-    end
-
-    if widget.getPaddingLeft then
-        width = width + (widget:getPaddingLeft() or 0) + (widget:getPaddingRight() or 0)
-    end
-
-    return width
-end
-
 local function formatHistoryDate(timestamp)
     if not timestamp or timestamp == 0 then
         return tr('Unknown')
@@ -135,25 +115,6 @@ local function resolveHistoryList(panel)
         panel.historyList = list
     end
     return list
-end
-
-local function resolveHistoryHeader(panel)
-    if not panel then
-        return nil
-    end
-
-    if panel.historyHeaderAction and not panel.historyHeaderAction:isDestroyed() then
-        return panel.historyHeaderAction
-    end
-
-    local header = panel.historyHeader or panel:getChildById('historyHeader')
-    if not header then
-        return nil
-    end
-
-    panel.historyHeader = header
-    panel.historyHeaderAction = header:getChildById('historyHeaderAction') or header.historyHeaderAction
-    return panel.historyHeaderAction
 end
 
 local function registerResourceConfig(resourceType, config)
@@ -376,10 +337,6 @@ function onBrowseForgeHistory(page, lastPage, currentCount, historyList)
 
     historyListWidget:destroyChildren()
 
-    local headerAction = resolveHistoryHeader(historyPanel)
-    local maxActionWidth = measureWidgetContentWidth(headerAction)
-    local actionLabels = {}
-
     if historyList and #historyList > 0 then
         for _, entry in ipairs(historyList) do
             local row = g_ui.createWidget('HistoryForgePanel', historyListWidget)
@@ -392,11 +349,6 @@ function onBrowseForgeHistory(page, lastPage, currentCount, historyList)
                 local actionLabel = row:getChildById('action')
                 if actionLabel then
                     actionLabel:setText(historyActionLabels[entry.actionType] or tr('Unknown'))
-                    local actionWidth = measureWidgetContentWidth(actionLabel)
-                    if actionWidth > 0 then
-                        maxActionWidth = math.max(maxActionWidth or 0, actionWidth)
-                        table.insert(actionLabels, actionLabel)
-                    end
                 end
 
                 local detailLabel = row:getChildById('details')
@@ -416,11 +368,6 @@ function onBrowseForgeHistory(page, lastPage, currentCount, historyList)
             local actionLabel = emptyRow:getChildById('action')
             if actionLabel then
                 actionLabel:setText(tr('No history'))
-                local actionWidth = measureWidgetContentWidth(actionLabel)
-                if actionWidth > 0 then
-                    maxActionWidth = math.max(maxActionWidth or 0, actionWidth)
-                    table.insert(actionLabels, actionLabel)
-                end
             end
 
             local detailLabel = emptyRow:getChildById('details')
@@ -443,18 +390,6 @@ function onBrowseForgeHistory(page, lastPage, currentCount, historyList)
     local nextButton = historyPanel.nextPageButton or historyPanel:getChildById('nextPageButton')
     if nextButton then
         nextButton:setVisible(lastPage > page)
-    end
-
-    if maxActionWidth and maxActionWidth > 0 then
-        if headerAction then
-            headerAction:setWidth(maxActionWidth)
-        end
-
-        for _, label in ipairs(actionLabels) do
-            if not label:isDestroyed() then
-                label:setWidth(maxActionWidth)
-            end
-        end
     end
 end
 

--- a/modules/game_forge/game_forge.lua
+++ b/modules/game_forge/game_forge.lua
@@ -88,9 +88,9 @@ local forgeResourceConfig = {}
 local historyActionLabels = {
     [0] = tr('Fusion'),
     [1] = tr('Transfer'),
-    [2] = tr('Dust to Sliver'),
-    [3] = tr('Sliver to Core'),
-    [4] = tr('Increase Limit')
+    [2] = tr('Conversion'),
+    [3] = tr('Conversion'),
+    [4] = tr('Conversion')
 }
 
 local function measureWidgetContentWidth(widget)

--- a/modules/game_forge/otui/style.otui
+++ b/modules/game_forge/otui/style.otui
@@ -1,10 +1,13 @@
 HistoryForgePanel < UIWidget
   size: 468 20
+  focusable: false
+  padding: 0
   Label
     id: date
     !text: tr('Date')
     width: 150
     anchors.top: parent.top
+    anchors.bottom: parent.bottom
     anchors.left: parent.left
     text-align: left
     margin-left: 5
@@ -14,15 +17,18 @@ HistoryForgePanel < UIWidget
     !text: tr('Action')
     width: 150
     anchors.top: parent.top
+    anchors.bottom: parent.bottom
     anchors.left: prev.right
     text-align: left
     margin-top: 1
   Label
     id: details
     !text: tr('Details')
-    width: 220
     anchors.top: parent.top
+    anchors.bottom: parent.bottom
     anchors.left: prev.right
+    anchors.right: parent.right
     text-align: left
     margin-top: 1
-    border: 1 red
+    margin-right: 5
+    text-wrap: wordBreak

--- a/modules/game_forge/otui/style.otui
+++ b/modules/game_forge/otui/style.otui
@@ -2,8 +2,11 @@ HistoryForgePanel < UIWidget
   size: 0 20
   focusable: false
   padding: 0
+  layout: anchor
   anchors.left: parent.left
   anchors.right: parent.right
+  anchors.top: parent.top
+  anchors.bottom: parent.bottom
   Label
     id: date
     !text: tr('Date')

--- a/modules/game_forge/otui/style.otui
+++ b/modules/game_forge/otui/style.otui
@@ -1,7 +1,9 @@
 HistoryForgePanel < UIWidget
-  size: 468 20
+  size: 0 20
   focusable: false
   padding: 0
+  anchors.left: parent.left
+  anchors.right: parent.right
   Label
     id: date
     !text: tr('Date')
@@ -20,6 +22,9 @@ HistoryForgePanel < UIWidget
     anchors.left: prev.right
     text-align: left
     margin-top: 1
+    margin-left: 5
+    margin-right: 5
+    text-auto-resize: true
   Label
     id: details
     !text: tr('Details')
@@ -29,4 +34,6 @@ HistoryForgePanel < UIWidget
     anchors.right: parent.right
     text-align: left
     margin-top: 1
+    margin-left: 5
     margin-right: 5
+    text-wrap: true

--- a/modules/game_forge/otui/style.otui
+++ b/modules/game_forge/otui/style.otui
@@ -15,7 +15,6 @@ HistoryForgePanel < UIWidget
   Label
     id: action
     !text: tr('Action')
-    width: 150
     anchors.top: parent.top
     anchors.bottom: parent.bottom
     anchors.left: prev.right

--- a/modules/game_forge/otui/style.otui
+++ b/modules/game_forge/otui/style.otui
@@ -3,10 +3,6 @@ HistoryForgePanel < UIWidget
   focusable: false
   padding: 0
   layout: anchor
-  anchors.left: parent.left
-  anchors.right: parent.right
-  anchors.top: parent.top
-  anchors.bottom: parent.bottom
   Label
     id: date
     !text: tr('Date')

--- a/modules/game_forge/otui/style.otui
+++ b/modules/game_forge/otui/style.otui
@@ -31,4 +31,3 @@ HistoryForgePanel < UIWidget
     text-align: left
     margin-top: 1
     margin-right: 5
-    text-wrap: wordBreak

--- a/modules/game_forge/otui/style.otui
+++ b/modules/game_forge/otui/style.otui
@@ -19,11 +19,11 @@ HistoryForgePanel < UIWidget
     anchors.top: parent.top
     anchors.bottom: parent.bottom
     anchors.left: prev.right
+    width: 80
     text-align: left
     margin-top: 1
     margin-left: 5
     margin-right: 5
-    text-auto-resize: true
   Label
     id: details
     !text: tr('Details')

--- a/modules/game_forge/tab/history/history.css
+++ b/modules/game_forge/tab/history/history.css
@@ -14,13 +14,16 @@
     --border-color-right: #747474;
   }
 
-  .history-list {
-    display: block;
-    width: 100%;
-    height: 96%;
-    overflow: scroll;
-    margin-top: 15px;
-  }
+    .history-list {
+      position: absolute;
+      top: 18px;
+      left: 0px;
+      right: 0px;
+      bottom: 28px;
+      display: block;
+      overflow: auto;
+      padding: 2px;
+    }
 
   .header-widget {
     position: absolute;
@@ -46,18 +49,44 @@
     left: 300px;
   }
 
-  .separator-vertical {
-    position: absolute;
-    top: 0px;
-    width: 2px;
-    height: 100%;
-    display: block;
-  }
+    .separator-vertical {
+      position: absolute;
+      top: 0px;
+      bottom: 28px;
+      width: 2px;
+      display: block;
+    }
 
   .separator-1 {
     left: 149px;
   }
 
-  .separator-2 {
-    left: 299px;
-  }
+    .separator-2 {
+      left: 299px;
+    }
+
+    .history-footer {
+      position: absolute;
+      left: 0px;
+      right: 0px;
+      bottom: 0px;
+      height: 28px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 10px;
+      background-color: #363636;
+      --border-width-top: 1;
+      --border-color-top: #292a29;
+    }
+
+    .history-button {
+      width: 110px;
+      height: 22px;
+      margin: 0 8px;
+    }
+
+    .history-page-label {
+      flex: 1;
+      text-align: center;
+    }

--- a/modules/game_forge/tab/history/history.css
+++ b/modules/game_forge/tab/history/history.css
@@ -90,3 +90,7 @@
       flex: 1;
       text-align: center;
     }
+
+  #historyList Label {
+    text-wrap: wordBreak;
+  }

--- a/modules/game_forge/tab/history/history.css
+++ b/modules/game_forge/tab/history/history.css
@@ -20,7 +20,9 @@
     left: 0px;
     right: 0px;
     height: 16px;
-    display: flex;
+    display: grid;
+    grid-template-columns: 150px 2px 80px 2px 1fr;
+    column-gap: 4px;
     align-items: center;
     background-color: #363636;
     --border-width-bottom: 1;
@@ -34,14 +36,16 @@
     display: flex;
     align-items: center;
     padding: 0 5px;
+    box-sizing: border-box;
     --text-offset: 5 0;
     text-align: left;
+    width: 100%;
   }
 
   .history-header > .separator-vertical {
     height: 100%;
     width: 2px;
-    margin: 0 2px;
+    margin: 0;
   }
 
   .header-date {
@@ -55,8 +59,7 @@
   }
 
   .header-details {
-    flex: 1 1 auto;
-    min-width: 0;
+    width: 100%;
   }
 
     .history-list {
@@ -78,7 +81,6 @@
       height: 28px;
       display: flex;
       align-items: center;
-      justify-content: center;
       padding: 0 10px;
       background-color: #363636;
       --border-width-top: 1;
@@ -94,6 +96,10 @@
     .history-page-label {
       flex: 1;
       text-align: center;
+    }
+
+    #nextPageButton {
+      margin-left: auto;
     }
 
   #historyList Label {

--- a/modules/game_forge/tab/history/history.css
+++ b/modules/game_forge/tab/history/history.css
@@ -42,21 +42,21 @@
     height: 100%;
     width: 2px;
     margin: 0 2px;
-    flex: 0 0 auto;
   }
 
   .header-date {
-    flex: 0 0 150px;
+    width: 150px;
   }
 
   .header-action {
-    flex: 0 0 auto;
+    width: 80px;
     white-space: nowrap;
     margin-right: 5px;
   }
 
   .header-details {
     flex: 1 1 auto;
+    min-width: 0;
   }
 
     .history-list {

--- a/modules/game_forge/tab/history/history.css
+++ b/modules/game_forge/tab/history/history.css
@@ -52,6 +52,7 @@
   .header-action {
     flex: 0 0 auto;
     white-space: nowrap;
+    margin-right: 5px;
   }
 
   .header-details {
@@ -100,24 +101,5 @@
   }
 
   #historyList > * {
-    display: flex;
-    align-items: flex-start;
-    padding: 2px 5px;
-  }
-
-  #historyList > * > Label#date {
-    flex: 0 0 150px;
-  }
-
-  #historyList > * > Label#action {
-    flex: 0 0 auto;
-    white-space: nowrap;
-    margin-right: 5px;
-    width: auto;
-    min-width: 0;
-  }
-
-  #historyList > * > Label#details {
-    flex: 1 1 auto;
-    min-width: 0;
+    padding: 2px 0;
   }

--- a/modules/game_forge/tab/history/history.css
+++ b/modules/game_forge/tab/history/history.css
@@ -14,6 +14,50 @@
     --border-color-right: #747474;
   }
 
+  .history-header {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    right: 0px;
+    height: 16px;
+    display: flex;
+    align-items: center;
+    background-color: #363636;
+    --border-width-bottom: 1;
+    --border-color-bottom: #292a29;
+    --border-width-top: 1;
+    --border-color-top: black;
+  }
+
+  .history-header > .header-widget {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    padding: 0 5px;
+    --text-offset: 5 0;
+    text-align: left;
+  }
+
+  .history-header > .separator-vertical {
+    height: 100%;
+    width: 2px;
+    margin: 0 2px;
+    flex: 0 0 auto;
+  }
+
+  .header-date {
+    flex: 0 0 150px;
+  }
+
+  .header-action {
+    flex: 0 0 auto;
+    white-space: nowrap;
+  }
+
+  .header-details {
+    flex: 1 1 auto;
+  }
+
     .history-list {
       position: absolute;
       top: 18px;
@@ -22,47 +66,7 @@
       bottom: 28px;
       display: block;
       overflow: auto;
-      padding: 2px;
-    }
-
-  .header-widget {
-    position: absolute;
-    top: 0px;
-    size: 166 16;
-    --border-width-bottom: 1;
-    --border-color-bottom: #292a29;
-    background-color: #363636;
-    --text-offset: 5 0;
-    --border-width-top: 1;
-    --border-color-top: black;
-  }
-
-  .header-date {
-    left: 0px;
-  }
-
-  .header-action {
-    left: 150px;
-  }
-
-  .header-details {
-    left: 300px;
-  }
-
-    .separator-vertical {
-      position: absolute;
-      top: 0px;
-      bottom: 28px;
-      width: 2px;
-      display: block;
-    }
-
-  .separator-1 {
-    left: 149px;
-  }
-
-    .separator-2 {
-      left: 299px;
+      padding: 2px 2px 2px 0;
     }
 
     .history-footer {
@@ -93,4 +97,27 @@
 
   #historyList Label {
     text-wrap: wordBreak;
+  }
+
+  #historyList > * {
+    display: flex;
+    align-items: flex-start;
+    padding: 2px 5px;
+  }
+
+  #historyList > * > Label#date {
+    flex: 0 0 150px;
+  }
+
+  #historyList > * > Label#action {
+    flex: 0 0 auto;
+    white-space: nowrap;
+    margin-right: 5px;
+    width: auto;
+    min-width: 0;
+  }
+
+  #historyList > * > Label#details {
+    flex: 1 1 auto;
+    min-width: 0;
   }

--- a/modules/game_forge/tab/history/history.css
+++ b/modules/game_forge/tab/history/history.css
@@ -1,111 +1,107 @@
 .history-container {
-    position: absolute;
-    top: 0px;
-    left: 0px;
-    height: 100%;
-    background-color: #404040;
-    --border-width-top: 1;
-    --border-color-top: black;
-    --border-width-left: 1;
-    --border-color-left: black;
-    --border-width-bottom: 1;
-    --border-color-bottom: #747474;
-    --border-width-right: 1;
-    --border-color-right: #747474;
-  }
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  height: 100%;
+  background-color: #404040;
+  --border-width-top: 1;
+  --border-color-top: black;
+  --border-width-left: 1;
+  --border-color-left: black;
+  --border-width-bottom: 1;
+  --border-color-bottom: #747474;
+  --border-width-right: 1;
+  --border-color-right: #747474;
+}
 
-  .history-header {
-    position: absolute;
-    top: 0px;
-    left: 0px;
-    right: 0px;
-    height: 16px;
-    display: grid;
-    grid-template-columns: 150px 2px 80px 2px 1fr;
-    column-gap: 4px;
-    align-items: center;
-    background-color: #363636;
-    --border-width-bottom: 1;
-    --border-color-bottom: #292a29;
-    --border-width-top: 1;
-    --border-color-top: black;
-  }
+.history-list {
+  display: block;
+  width: 100%;
+  height: 96%;
+  overflow: scroll;
+  margin-top: 16px;
+}
 
-  .history-header > .header-widget {
-    height: 100%;
-    display: flex;
-    align-items: center;
-    padding: 0 5px;
-    box-sizing: border-box;
-    --text-offset: 5 0;
-    text-align: left;
-    width: 100%;
-  }
+.header-widget {
+  position: absolute;
+  top: 0px;
+  size: 166 16;
+  --border-width-bottom: 1;
+  --border-color-bottom: #292a29;
+  background-color: #363636;
+  --text-offset: 5 0;
+  --border-width-top: 1;
+  --border-color-top: black;
+}
 
-  .history-header > .separator-vertical {
-    height: 100%;
-    width: 2px;
-    margin: 0;
-  }
+.header-date {
+  left: 0px;
+}
 
-  .header-date {
-    width: 150px;
-  }
+.header-action {
+  left: 150px;
+}
 
-  .header-action {
-    width: 80px;
-    white-space: nowrap;
-    margin-right: 5px;
-  }
+.header-details {
+  left: 235px;
+  size: 230 16;
+}
 
-  .header-details {
-    width: 100%;
-  }
+.separator-vertical {
+  position: absolute;
+  top: 0px;
+  width: 2px;
+  height: 100%;
+  display: block;
+}
 
-    .history-list {
-      position: absolute;
-      top: 18px;
-      left: 0px;
-      right: 0px;
-      bottom: 28px;
-      display: block;
-      overflow: auto;
-      padding: 2px 2px 2px 0;
-    }
+.separator-1 {
+  left: 149px;
+}
 
-    .history-footer {
-      position: absolute;
-      left: 0px;
-      right: 0px;
-      bottom: 0px;
-      height: 28px;
-      display: flex;
-      align-items: center;
-      padding: 0 10px;
-      background-color: #363636;
-      --border-width-top: 1;
-      --border-color-top: #292a29;
-    }
+.separator-2 {
+  left: 234px;
+}
 
-    .history-button {
-      width: 110px;
-      height: 22px;
-      margin: 0 8px;
-    }
+.history-footer {
+  position: absolute;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  height: 28px;
+  background-color: #363636;
+  --border-width-top: 1;
+  --border-color-top: #292a29;
+  width: 453px;
+}
 
-    .history-page-label {
-      flex: 1;
-      text-align: center;
-    }
+.history-button {
+  height: 20px;
+  width: 100px;
+  text-align: center;
+}
 
-    #nextPageButton {
-      margin-left: auto;
-    }
+.history-button-previous {
+  position: absolute;
+  bottom: 5px;
+  left: 5px;
+}
 
-  #historyList Label {
-    text-wrap: wordBreak;
-  }
+.history-button-next {
+  position: absolute;
+  bottom: 5px;
+  left: 350px;
+}
 
-  #historyList > * {
-    padding: 2px 0;
-  }
+.history-page-label {
+  width: 100%;
+  height: 28px;
+  margin: 0 auto;
+  position: absolute;
+  bottom: 0px;
+  left: 200px;
+}
+
+#nextPageButton {
+  margin-left: auto;
+}

--- a/modules/game_forge/tab/history/history.html
+++ b/modules/game_forge/tab/history/history.html
@@ -3,11 +3,11 @@
   <TextList id="historyList" anchor="parent" class="history-list"></TextList>
 
   <UIWidget id="historyHeader" anchor="parent" class="history-header">
-    <UIWidget id="historyHeaderDate" class="header-widget header-date" text="Date"></UIWidget>
+    <Label id="historyHeaderDate" class="header-widget header-date" text="Date"></Label>
     <img class="separator-vertical" src="/images/ui/separator_vertical"/>
-    <UIWidget id="historyHeaderAction" class="header-widget header-action" text="Action"></UIWidget>
+    <Label id="historyHeaderAction" class="header-widget header-action" text="Action"></Label>
     <img class="separator-vertical" src="/images/ui/separator_vertical"/>
-    <UIWidget id="historyHeaderDetails" class="header-widget header-details" text="Details"></UIWidget>
+    <Label id="historyHeaderDetails" class="header-widget header-details" text="Details"></Label>
   </UIWidget>
 
   <UIWidget id="historyFooter" class="history-footer">

--- a/modules/game_forge/tab/history/history.html
+++ b/modules/game_forge/tab/history/history.html
@@ -8,6 +8,14 @@
 
   <img class="separator-vertical separator-1" src="/images/ui/separator_vertical"/>
   <img class="separator-vertical separator-2" src="/images/ui/separator_vertical"/>
+
+  <UIWidget id="historyFooter" class="history-footer">
+    <UIButton id="previousPageButton" class="history-button" text="Previous Page"
+      visible="false" onclick="self:onHistoryPreviousPage()" />
+    <UIWidget id="historyPageLabel" class="history-page-label" text="Page 1/1"></UIWidget>
+    <UIButton id="nextPageButton" class="history-button" text="Next Page"
+      onclick="self:onHistoryNextPage()" />
+  </UIWidget>
 </div>
 </html>
 

--- a/modules/game_forge/tab/history/history.html
+++ b/modules/game_forge/tab/history/history.html
@@ -1,22 +1,51 @@
 <html>
-<div id="history" class="history-container" anchor="parent">
-  <TextList id="historyList" anchor="parent" class="history-list"></TextList>
+  <div id="history" class="history-container" anchor="parent">
+    <TextList id="historyList" anchor="parent" class="history-list"></TextList>
 
-  <UIWidget id="historyHeader" anchor="parent" class="history-header">
-    <Label id="historyHeaderDate" class="header-widget header-date" text="Date"></Label>
-    <img class="separator-vertical" src="/images/ui/separator_vertical"/>
-    <Label id="historyHeaderAction" class="header-widget header-action" text="Action"></Label>
-    <img class="separator-vertical" src="/images/ui/separator_vertical"/>
-    <Label id="historyHeaderDetails" class="header-widget header-details" text="Details"></Label>
-  </UIWidget>
+    <UIWidget
+      anchor="parent"
+      class="header-widget header-date"
+      text="Date"
+    ></UIWidget>
+    <UIWidget
+      anchor="parent"
+      class="header-widget header-action"
+      text="Action"
+    ></UIWidget>
+    <UIWidget
+      anchor="parent"
+      class="header-widget header-details"
+      text="Details"
+    ></UIWidget>
 
-  <UIWidget id="historyFooter" class="history-footer">
-    <UIButton id="previousPageButton" class="history-button" text="Previous Page"
-      visible="false" onclick="self:onHistoryPreviousPage()" />
-    <UIWidget id="historyPageLabel" class="history-page-label" text="Page 1/1"></UIWidget>
-    <UIButton id="nextPageButton" class="history-button" text="Next Page"
-      onclick="self:onHistoryNextPage()" />
-  </UIWidget>
-</div>
+    <img
+      class="separator-vertical separator-1"
+      src="/images/ui/separator_vertical"
+    />
+    <img
+      class="separator-vertical separator-2"
+      src="/images/ui/separator_vertical"
+    />
+
+    <UIWidget id="historyFooter" class="history-footer">
+      <UIButton
+        id="previousPageButton"
+        class="history-button history-button-previous"
+        text="Previous Page"
+        visible="false"
+        onclick="self:onHistoryPreviousPage()"
+      />
+      <UIWidget
+        id="historyPageLabel"
+        class="history-page-label"
+        text="Page 1/1"
+      ></UIWidget>
+      <UIButton
+        id="nextPageButton"
+        class="history-button history-button-next"
+        text="Next Page"
+        onclick="self:onHistoryNextPage()"
+      />
+    </UIWidget>
+  </div>
 </html>
-

--- a/modules/game_forge/tab/history/history.html
+++ b/modules/game_forge/tab/history/history.html
@@ -3,11 +3,11 @@
   <TextList id="historyList" anchor="parent" class="history-list"></TextList>
 
   <UIWidget id="historyHeader" anchor="parent" class="history-header">
-    <UIWidget class="header-widget header-date" text="Date"></UIWidget>
+    <UIWidget id="historyHeaderDate" class="header-widget header-date" text="Date"></UIWidget>
     <img class="separator-vertical" src="/images/ui/separator_vertical"/>
-    <UIWidget class="header-widget header-action" text="Action"></UIWidget>
+    <UIWidget id="historyHeaderAction" class="header-widget header-action" text="Action"></UIWidget>
     <img class="separator-vertical" src="/images/ui/separator_vertical"/>
-    <UIWidget class="header-widget header-details" text="Details"></UIWidget>
+    <UIWidget id="historyHeaderDetails" class="header-widget header-details" text="Details"></UIWidget>
   </UIWidget>
 
   <UIWidget id="historyFooter" class="history-footer">

--- a/modules/game_forge/tab/history/history.html
+++ b/modules/game_forge/tab/history/history.html
@@ -2,12 +2,13 @@
 <div id="history" class="history-container" anchor="parent">
   <TextList id="historyList" anchor="parent" class="history-list"></TextList>
 
-  <UIWidget anchor="parent" class="header-widget header-date" text="Date"></UIWidget>
-  <UIWidget anchor="parent" class="header-widget header-action" text="Action"></UIWidget>
-  <UIWidget anchor="parent" class="header-widget header-details" text="Details"></UIWidget>
-
-  <img class="separator-vertical separator-1" src="/images/ui/separator_vertical"/>
-  <img class="separator-vertical separator-2" src="/images/ui/separator_vertical"/>
+  <UIWidget id="historyHeader" anchor="parent" class="history-header">
+    <UIWidget class="header-widget header-date" text="Date"></UIWidget>
+    <img class="separator-vertical" src="/images/ui/separator_vertical"/>
+    <UIWidget class="header-widget header-action" text="Action"></UIWidget>
+    <img class="separator-vertical" src="/images/ui/separator_vertical"/>
+    <UIWidget class="header-widget header-details" text="Details"></UIWidget>
+  </UIWidget>
 
   <UIWidget id="historyFooter" class="history-footer">
     <UIButton id="previousPageButton" class="history-button" text="Previous Page"

--- a/modules/game_forge/tab/history/history.lua
+++ b/modules/game_forge/tab/history/history.lua
@@ -3,3 +3,26 @@
 function showHistory()
   return forgeController:loadTab('history')
 end
+
+function forgeController:onHistoryPreviousPage()
+  local state = self.historyState or {}
+  local currentPage = tonumber(state.page) or 1
+
+  if currentPage <= 1 then
+    return
+  end
+
+  g_game.sendForgeBrowseHistoryRequest(currentPage - 1)
+end
+
+function forgeController:onHistoryNextPage()
+  local state = self.historyState or {}
+  local currentPage = tonumber(state.page) or 1
+  local lastPage = tonumber(state.lastPage) or currentPage
+
+  if currentPage >= lastPage then
+    return
+  end
+
+  g_game.sendForgeBrowseHistoryRequest(currentPage + 1)
+end


### PR DESCRIPTION
## Summary
- render the forge history list with formatted date, action, and description entries
- add pagination controls that request previous and next history pages when available

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfa2edf878832eb603c1767641a9db