### PR TITLE
Ensure forge history pagination buttons revert color after release

### DIFF
--- a/modules/game_forge/tab/history/history.lua
+++ b/modules/game_forge/tab/history/history.lua
@@ -1,7 +1,51 @@
 -- Todo 
 -- change to TypeScript
+local function configurePaginationButton(button)
+  if not button or button.__historyPaginationHandlers then
+    return
+  end
+
+  button.__historyPaginationHandlers = true
+
+  connect(button, {
+    onMousePress = function(widget, mousePos, mouseButton)
+      if mouseButton ~= MouseLeftButton then
+        return false
+      end
+
+      widget.__historyOriginalColor = widget:getColor()
+      widget:setColor('#ff0000')
+      return false
+    end,
+    onMouseRelease = function(widget, mousePos, mouseButton)
+      if mouseButton ~= MouseLeftButton then
+        return false
+      end
+
+      local originalColor = widget.__historyOriginalColor
+      if originalColor then
+        widget:setColor(originalColor)
+      else
+        widget:setColor('#ffffff')
+      end
+      return false
+    end
+  })
+end
+
+local function configureHistoryPaginationButtons(historyPanel)
+  if not historyPanel then
+    return
+  end
+
+  configurePaginationButton(historyPanel.previousPageButton or historyPanel:getChildById('previousPageButton'))
+  configurePaginationButton(historyPanel.nextPageButton or historyPanel:getChildById('nextPageButton'))
+end
+
 function showHistory()
-  return forgeController:loadTab('history')
+  local historyPanel = forgeController:loadTab('history')
+  configureHistoryPaginationButtons(historyPanel)
+  return historyPanel
 end
 
 function forgeController:onHistoryPreviousPage()
@@ -11,6 +55,9 @@ function forgeController:onHistoryPreviousPage()
   if currentPage <= 1 then
     return
   end
+
+  local historyPanel = self:loadTab('history')
+  configureHistoryPaginationButtons(historyPanel)
 
   g_game.sendForgeBrowseHistoryRequest(currentPage - 1)
 end
@@ -23,6 +70,9 @@ function forgeController:onHistoryNextPage()
   if currentPage >= lastPage then
     return
   end
+
+  local historyPanel = self:loadTab('history')
+  configureHistoryPaginationButtons(historyPanel)
 
   g_game.sendForgeBrowseHistoryRequest(currentPage + 1)
 end


### PR DESCRIPTION
## Summary
- hook history pagination buttons to turn red while pressed and restore their original color when released
- reuse the behavior setup whenever the history tab is loaded so the handlers stay active

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfc2ede5c8832ea9a98d4879b2f4a6