### PR TITLE
Update fusion UI to highlight selected item upgrades

### DIFF
--- a/modules/game_forge/game_forge.lua
+++ b/modules/game_forge/game_forge.lua
@@ -274,8 +274,16 @@ local function resolveFusionTabContext()
             selectionPanel = selectionPanel,
             selectionItemsPanel = nil,
             targetItem = getFirstChildByStyleName(panel, 'fusion-slot-item'),
+            targetTierLabel = panel.fusionTargetTierLabel or panel:recursiveGetChildById('fusionTargetTierLabel'),
+            targetPlaceholder = panel.fusionTargetPlaceholder or panel:recursiveGetChildById('fusionTargetPlaceholder'),
             resultArea = resultArea,
             placeholder = getFirstChildByStyleName(resultArea, 'forge-result-placeholder'),
+            selectedItemIcon = resultArea and (resultArea.fusionSelectedItemIcon
+                or resultArea:recursiveGetChildById('fusionSelectedItemIcon')),
+            selectedItemPlaceholder = resultArea and (resultArea.fusionSelectedItemPlaceholder
+                or resultArea:recursiveGetChildById('fusionSelectedItemPlaceholder')),
+            selectedItemCountLabel = resultArea and (resultArea.fusionSelectedItemCount
+                or resultArea:recursiveGetChildById('fusionSelectedItemCount')),
             convergenceSection = convergenceSection,
             fusionButton = nil,
             fusionButtonItem = nil,
@@ -317,6 +325,29 @@ local function resolveFusionTabContext()
             local labels = getChildrenByStyleName(costContainer, 'forge-full-width-label')
             fusionTabContext.costLabel = labels[1]
         end
+    end
+
+    if fusionTabContext.targetTierLabel and fusionTabContext.targetTierLabel:isDestroyed() then
+        fusionTabContext.targetTierLabel = panel:recursiveGetChildById('fusionTargetTierLabel')
+    end
+
+    if fusionTabContext.targetPlaceholder and fusionTabContext.targetPlaceholder:isDestroyed() then
+        fusionTabContext.targetPlaceholder = panel:recursiveGetChildById('fusionTargetPlaceholder')
+    end
+
+    if fusionTabContext.selectedItemIcon and fusionTabContext.selectedItemIcon:isDestroyed() then
+        fusionTabContext.selectedItemIcon = fusionTabContext.resultArea
+            and fusionTabContext.resultArea:recursiveGetChildById('fusionSelectedItemIcon')
+    end
+
+    if fusionTabContext.selectedItemPlaceholder and fusionTabContext.selectedItemPlaceholder:isDestroyed() then
+        fusionTabContext.selectedItemPlaceholder = fusionTabContext.resultArea
+            and fusionTabContext.resultArea:recursiveGetChildById('fusionSelectedItemPlaceholder')
+    end
+
+    if fusionTabContext.selectedItemCountLabel and fusionTabContext.selectedItemCountLabel:isDestroyed() then
+        fusionTabContext.selectedItemCountLabel = fusionTabContext.resultArea
+            and fusionTabContext.resultArea:recursiveGetChildById('fusionSelectedItemCount')
     end
 
     if fusionTabContext.convergenceSection and (not fusionTabContext.convergenceItemsPanel or fusionTabContext.convergenceItemsPanel:isDestroyed()) then
@@ -730,15 +761,22 @@ function forgeController:configureFusionConversionPanel(selectedWidget)
 
     self.fusionItem = itemPtr
     self.fusionItemCount = itemCount
+    self.fusionItemTier = itemTier
+    self.fusionTargetTier = itemTier + 1
+    self.fusionSelectedItemInfo = selectedWidget.fusionItemInfo
 
     if context.targetItem then
         context.targetItem:setItemId(itemPtr:getId())
-        context.targetItem:setItemCount(itemCount)
-        ItemsDatabase.setTier(context.targetItem, itemPtr)
+        context.targetItem:setItemCount(1)
+        ItemsDatabase.setTier(context.targetItem, itemTier + 1)
     end
 
-    if context.placeholder then
-        context.placeholder:setVisible(false)
+    if context.targetTierLabel then
+        context.targetTierLabel:setText(tr('Upgrade to tier %d', math.max(itemTier + 1, 0)))
+    end
+
+    if context.targetPlaceholder then
+        context.targetPlaceholder:setVisible(false)
     end
 
     if context.convergenceSection then
@@ -755,6 +793,21 @@ function forgeController:configureFusionConversionPanel(selectedWidget)
         context.fusionButtonItemTo:setItemId(itemPtr:getId())
         context.fusionButtonItemTo:setItemCount(1)
         ItemsDatabase.setTier(context.fusionButtonItemTo, itemTier + 1)
+    end
+
+    if context.selectedItemIcon then
+        context.selectedItemIcon:setItemId(itemPtr:getId())
+        context.selectedItemIcon:setItemCount(itemCount)
+        ItemsDatabase.setTier(context.selectedItemIcon, itemTier)
+        context.selectedItemIcon:setVisible(true)
+    end
+
+    if context.selectedItemPlaceholder then
+        context.selectedItemPlaceholder:setVisible(false)
+    end
+
+    if context.selectedItemCountLabel then
+        context.selectedItemCountLabel:setText(string.format('%d / 1', math.max(itemCount, 1)))
     end
 
     if context.convergenceItemsPanel then
@@ -846,11 +899,22 @@ function forgeController:resetFusionConversionPanel()
     self.fusionItem = nil
     self.fusionItemCount = nil
     self.fusionSelectedItem = nil
+    self.fusionSelectedItemInfo = nil
+    self.fusionItemTier = nil
+    self.fusionTargetTier = nil
 
     if context.targetItem then
         context.targetItem:setItemId(0)
         context.targetItem:setItemCount(0)
         ItemsDatabase.setTier(context.targetItem, 0)
+    end
+
+    if context.targetTierLabel then
+        context.targetTierLabel:setText(tr('Select an item to preview the upgrade'))
+    end
+
+    if context.targetPlaceholder then
+        context.targetPlaceholder:setVisible(true)
     end
 
     if context.placeholder then
@@ -859,6 +923,21 @@ function forgeController:resetFusionConversionPanel()
 
     if context.convergenceSection then
         context.convergenceSection:setVisible(false)
+    end
+
+    if context.selectedItemIcon then
+        context.selectedItemIcon:setItemId(0)
+        context.selectedItemIcon:setItemCount(0)
+        ItemsDatabase.setTier(context.selectedItemIcon, 0)
+        context.selectedItemIcon:setVisible(false)
+    end
+
+    if context.selectedItemPlaceholder then
+        context.selectedItemPlaceholder:setVisible(true)
+    end
+
+    if context.selectedItemCountLabel then
+        context.selectedItemCountLabel:setText('0 / 1')
     end
 
     if context.fusionButtonItem then

--- a/modules/game_forge/tab/fusion/fusion.css
+++ b/modules/game_forge/tab/fusion/fusion.css
@@ -1,7 +1,42 @@
-.fusion-target-slot {
+.fusion-selection-content {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    width: 165px;
+  }
+
+.fusion-target-panel {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    margin-bottom: 6px;
+  }
+
+  .fusion-target-label {
+    width: 100%;
+    color: #f8c96b;
+    font-size: 11px;
+    text-transform: uppercase;
+    text-align: left;
+  }
+
+  .fusion-target-slot {
     width: 158px;
     height: 82px;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     --icon: /images/ui/icon-questionmark
+  }
+
+  .fusion-target-slot .forge-question-icon {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
   }
 
   .fusion-item-box {

--- a/modules/game_forge/tab/fusion/fusion.html
+++ b/modules/game_forge/tab/fusion/fusion.html
@@ -2,8 +2,17 @@
 <div id="fusion" anchor="parent" class="fusion-container forge-tab" layout="type: verticalBox; spacing: 5">
   <div id="fusionSelectionArea" class="minipanel forge-selection-area forge-selection-area--primary fusion-selection-area"
     title="Select Item For Fusion">
-    <div id="fusionSelectionGrid" class="slot-grid forge-slot-grid UIScrollArea"
-      layout="type: grid; cell-size: 36 38;flow: true"></div>
+    <div class="fusion-selection-content">
+      <div class="fusion-target-panel">
+        <Label id="fusionTargetTierLabel" class="fusion-target-label" text="Select an item to preview the upgrade"></Label>
+        <UIWidget class="fusion-target-slot">
+          <UIItem id="fusionTargetSlotItem" class="fusion-slot-item"></UIItem>
+          <img id="fusionTargetPlaceholder" class="forge-question-icon" src="/images/ui/icon-questionmark" />
+        </UIWidget>
+      </div>
+      <div id="fusionSelectionGrid" class="slot-grid forge-slot-grid UIScrollArea"
+        layout="type: grid; cell-size: 36 38;flow: true"></div>
+    </div>
     <div class="forge-selection-side" style="margin-left: 0px;">
       <img class="forge-arrow-large" src="/images/arrows/icon-arrow-rightlarge" />
       <img class="forge-arrow-large" src="/images/arrows/icon-arrow-rightlarge" />
@@ -11,22 +20,19 @@
       <input class="forge-convergence-checkbox" type="checkbox" text="Convergence"
         onchange="self:onCheckChangeConvergence(event)" />
     </div>
-    <UIWidget class="fusion-target-slot">
-      <UIItem class="fusion-slot-item"></UIItem>
-    </UIWidget>
   </div>
 
   <div id="test" class="minipanel forge-selection-area forge-selection-area--secondary fusion-result-area"
     focusable="false" title="Further Items Needed For fusion">
     <div class="forge-result-placeholder" focusable="false" *visible="not self.modeFusion">
       <div class="forge-required-block">
-        <div class="forge-card">
-          <UIItem class="forge-item-icon"></UIItem>
-          <img class="forge-question-icon" src="/images/ui/icon-questionmark" />
+        <div id="fusionSelectedItemCard" class="forge-card">
+          <UIItem id="fusionSelectedItemIcon" class="forge-item-icon" show-count="true"></UIItem>
+          <img id="fusionSelectedItemPlaceholder" class="forge-question-icon" src="/images/ui/icon-questionmark" />
         </div>
         <div class="forge-counter">
-          <Label class="forge-full-width-label" text="0 / 1"></Label>
-          
+          <Label id="fusionSelectedItemCount" class="forge-full-width-label" text="0 / 1"></Label>
+
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- add a target preview panel to the fusion selection area and show the selected item in the requirements card
- style the fusion tab so the new preview content aligns with the existing layout
- update the fusion controller to store the selected item tier and toggle the new UI state when selections change

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0033233b8832ea959fc4b4fba06fb