### PR TITLE
Align forge module callbacks with protocol naming

### DIFF
--- a/modules/game_forge/forge.lua
+++ b/modules/game_forge/forge.lua
@@ -37,6 +37,9 @@ function init()
     onForgeFusion = ForgeSystem.onForgeFusion,
     onForgeTransfer = ForgeSystem.onForgeTransfer,
     onForgeHistory = ForgeSystem.onForgeHistory,
+    onOpenForge = ForgeSystem.onOpenForge,
+    onBrowseForgeHistory = ForgeSystem.onBrowseForgeHistory,
+    onCloseForgeCloseWindows = ForgeSystem.onCloseForgeCloseWindows,
     onResourceBalance = onResourceBalance,
     onGameEnd = offlineForge,
   })
@@ -58,6 +61,9 @@ function terminate()
     onForgeFusion = ForgeSystem.onForgeFusion,
     onForgeTransfer = ForgeSystem.onForgeTransfer,
     onForgeHistory = ForgeSystem.onForgeHistory,
+    onOpenForge = ForgeSystem.onOpenForge,
+    onBrowseForgeHistory = ForgeSystem.onBrowseForgeHistory,
+    onCloseForgeCloseWindows = ForgeSystem.onCloseForgeCloseWindows,
     onResourceBalance = onResourceBalance,
     onGameEnd = offlineForge,
   })
@@ -158,7 +164,11 @@ function loadMenu(menuId)
   elseif menuId == 'historyMenu' then
     historyMenu:show(true)
     historyMenuButton:setChecked(true)
-    g_game.requestForgeHistory()
+    if g_game.sendForgeBrowseHistoryRequest then
+      g_game.sendForgeBrowseHistoryRequest(1)
+    else
+      g_game.requestForgeHistory()
+    end
   end
 
   local player = g_game.getLocalPlayer()


### PR DESCRIPTION
## Summary
- hook the legacy forge module into the new onOpenForge/onBrowseForgeHistory/onCloseForgeCloseWindows protocol callbacks
- translate the structured forge open data into the tables expected by the existing UI logic
- fall back to the legacy history request when the new sendForgeBrowseHistoryRequest helper is unavailable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0291e5d30832e8a7b5814343d921f