### PR TITLE
Adjust fusion core button availability

### DIFF
--- a/modules/game_forge/game_forge.lua
+++ b/modules/game_forge/game_forge.lua
@@ -36,6 +36,7 @@ local forgeResourceTypes = {
 }
 
 local FUSION_CORE_ACTIVE_COLOR = '#619258'
+local FUSION_CORE_DEFAULT_COLOR = '#d33c3c'
 
 local function defaultResourceFormatter(value)
     local numericValue = tonumber(value) or 0
@@ -650,8 +651,24 @@ function forgeController:updateFusionCoreButtons()
         end
 
         local baseColor = context[baseColorField]
+        if type(baseColor) == 'string' then
+            local normalized = baseColor:lower()
+            if normalized == '#ffffff' or normalized == 'white' then
+                baseColor = FUSION_CORE_DEFAULT_COLOR
+                context[baseColorField] = baseColor
+            end
+        end
         if not baseColor then
             baseColor = label:getColor()
+            if type(baseColor) == 'string' then
+                local normalized = baseColor:lower()
+                if normalized == '#ffffff' or normalized == 'white' then
+                    baseColor = nil
+                end
+            end
+            if not baseColor or baseColor == '' then
+                baseColor = FUSION_CORE_DEFAULT_COLOR
+            end
             context[baseColorField] = baseColor
         end
 

--- a/modules/game_forge/game_forge.lua
+++ b/modules/game_forge/game_forge.lua
@@ -23,6 +23,10 @@ forgeController.historyState = {
     lastPage = 1,
     currentCount = 0
 }
+forgeController.fusionCoreSelections = {
+    success = false,
+    tier = false
+}
 local forgeButton
 
 local forgeResourceTypes = {
@@ -359,6 +363,18 @@ local function resolveFusionTabContext()
         end
     end
 
+    if fusionTabContext.resultArea and (not fusionTabContext.successCoreButton or fusionTabContext.successCoreButton:isDestroyed()) then
+        fusionTabContext.successCoreButton = fusionTabContext.panel.fusionImproveButton
+            or fusionTabContext.resultArea.fusionImproveButton
+            or fusionTabContext.panel:recursiveGetChildById('fusionImproveButton')
+    end
+
+    if fusionTabContext.resultArea and (not fusionTabContext.tierCoreButton or fusionTabContext.tierCoreButton:isDestroyed()) then
+        fusionTabContext.tierCoreButton = fusionTabContext.panel.fusionReduceButton
+            or fusionTabContext.resultArea.fusionReduceButton
+            or fusionTabContext.panel:recursiveGetChildById('fusionReduceButton')
+    end
+
     if fusionTabContext.convergenceSection and (not fusionTabContext.convergenceItemsPanel or fusionTabContext.convergenceItemsPanel:isDestroyed()) then
         local convergenceGrid = fusionTabContext.convergenceSection.fusionConvergenceGrid
             or (fusionTabContext.resultArea and fusionTabContext.resultArea.fusionConvergenceGrid)
@@ -518,6 +534,176 @@ function forgeController:updateResourceBalances(resourceType)
             updateStatusConfig(self, config, player)
         end
     end
+
+    if not resourceType or resourceType == forgeResourceTypes.cores then
+        self:updateFusionCoreButtons()
+    end
+end
+
+function forgeController:updateFusionCoreButtons()
+    if not self.ui then
+        return
+    end
+
+    local context = resolveFusionTabContext()
+    if not context then
+        return
+    end
+
+    local successButton = context.successCoreButton
+    if not successButton or successButton:isDestroyed() then
+        successButton = context.panel and context.panel:recursiveGetChildById('fusionImproveButton')
+        context.successCoreButton = successButton
+    end
+
+    local tierButton = context.tierCoreButton
+    if not tierButton or tierButton:isDestroyed() then
+        tierButton = context.panel and context.panel:recursiveGetChildById('fusionReduceButton')
+        context.tierCoreButton = tierButton
+    end
+
+    if not successButton and not tierButton then
+        return
+    end
+
+    local selections = self.fusionCoreSelections
+    if type(selections) ~= 'table' then
+        selections = {
+            success = false,
+            tier = false
+        }
+        self.fusionCoreSelections = selections
+    end
+
+    local player = g_game.getLocalPlayer()
+    local coreBalance = 0
+    if player then
+        coreBalance = player:getResourceBalance(forgeResourceTypes.cores) or 0
+    end
+
+    local function setButtonState(button, selected, enabled)
+        if not button or button:isDestroyed() then
+            return
+        end
+
+        if button.setOn then
+            button:setOn(selected)
+        end
+
+        if button.setEnabled then
+            button:setEnabled(enabled or selected)
+        end
+    end
+
+    if coreBalance <= 0 then
+        selections.success = false
+        selections.tier = false
+        setButtonState(successButton, false, false)
+        setButtonState(tierButton, false, false)
+        return
+    end
+
+    local selectedSuccess = selections.success and true or false
+    local selectedTier = selections.tier and true or false
+
+    local selectedCount = (selectedSuccess and 1 or 0) + (selectedTier and 1 or 0)
+    if selectedCount > coreBalance then
+        if selectedTier then
+            selectedTier = false
+            selections.tier = false
+            selectedCount = selectedCount - 1
+        end
+        if selectedCount > coreBalance and selectedSuccess then
+            selectedSuccess = false
+            selections.success = false
+            selectedCount = selectedCount - 1
+        end
+    end
+
+    local hasAvailableCore = coreBalance > selectedCount
+
+    local successEnabled = selectedSuccess or hasAvailableCore
+    local tierEnabled = selectedTier or hasAvailableCore
+
+    if coreBalance == 1 then
+        if selectedSuccess and not selectedTier then
+            tierEnabled = false
+        elseif selectedTier and not selectedSuccess then
+            successEnabled = false
+        end
+    end
+
+    setButtonState(successButton, selectedSuccess, successEnabled)
+    setButtonState(tierButton, selectedTier, tierEnabled)
+end
+
+function forgeController:onToggleFusionCore(coreType)
+    if not self.ui then
+        return
+    end
+
+    if coreType ~= 'success' and coreType ~= 'tier' then
+        return
+    end
+
+    local context = resolveFusionTabContext()
+    if not context then
+        return
+    end
+
+    local button
+    if coreType == 'success' then
+        button = context.successCoreButton
+        if not button or button:isDestroyed() then
+            context.successCoreButton = context.panel and context.panel:recursiveGetChildById('fusionImproveButton') or nil
+            button = context.successCoreButton
+        end
+    else
+        button = context.tierCoreButton
+        if not button or button:isDestroyed() then
+            context.tierCoreButton = context.panel and context.panel:recursiveGetChildById('fusionReduceButton') or nil
+            button = context.tierCoreButton
+        end
+    end
+
+    if not button or button:isDestroyed() then
+        return
+    end
+
+    local selections = self.fusionCoreSelections
+    if type(selections) ~= 'table' then
+        selections = {
+            success = false,
+            tier = false
+        }
+        self.fusionCoreSelections = selections
+    end
+
+    local isSelected = selections[coreType] and true or false
+
+    local player = g_game.getLocalPlayer()
+    local coreBalance = 0
+    if player then
+        coreBalance = player:getResourceBalance(forgeResourceTypes.cores) or 0
+    end
+
+    if isSelected then
+        selections[coreType] = false
+        self:updateFusionCoreButtons()
+        return
+    end
+
+    local otherType = coreType == 'success' and 'tier' or 'success'
+    local otherSelected = selections[otherType] and 1 or 0
+    if coreBalance <= otherSelected then
+        if g_game.playCancelSound then
+            g_game.playCancelSound()
+        end
+        return
+    end
+
+    selections[coreType] = true
+    self:updateFusionCoreButtons()
 end
 
 function forgeController:onInit()
@@ -704,6 +890,11 @@ function forgeController:onGameStart()
         page = 1,
         lastPage = 1,
         currentCount = 0
+    }
+
+    self.fusionCoreSelections = {
+        success = false,
+        tier = false
     }
 end
 
@@ -893,6 +1084,8 @@ function forgeController:configureFusionConversionPanel(selectedWidget)
         fusionConvergenceRadioGroup:selectWidget(firstWidget, true)
         onFusionConvergenceSelectionChange(fusionConvergenceRadioGroup, firstWidget)
     end
+
+    self:updateFusionCoreButtons()
 end
 
 function forgeController:resetFusionConversionPanel()
@@ -962,6 +1155,18 @@ function forgeController:resetFusionConversionPanel()
         context.costLabel:setText('???')
         context.costLabel:setColor('$var-text-cip-color')
     end
+
+    if type(self.fusionCoreSelections) ~= 'table' then
+        self.fusionCoreSelections = {
+            success = false,
+            tier = false
+        }
+    else
+        self.fusionCoreSelections.success = false
+        self.fusionCoreSelections.tier = false
+    end
+
+    self:updateFusionCoreButtons()
 end
 
 function forgeController:updateFusionItems(fusionData)

--- a/modules/game_forge/game_forge.lua
+++ b/modules/game_forge/game_forge.lua
@@ -35,6 +35,8 @@ local forgeResourceTypes = {
     cores = ResourceTypes and ResourceTypes.FORGE_CORES or 72
 }
 
+local FUSION_CORE_ACTIVE_COLOR = '#619258'
+
 local function defaultResourceFormatter(value)
     local numericValue = tonumber(value) or 0
     return tostring(numericValue)
@@ -367,12 +369,14 @@ local function resolveFusionTabContext()
         fusionTabContext.successCoreButton = fusionTabContext.panel.fusionImproveButton
             or fusionTabContext.resultArea.fusionImproveButton
             or fusionTabContext.panel:recursiveGetChildById('fusionImproveButton')
+        fusionTabContext.successCoreButtonBaseColor = nil
     end
 
     if fusionTabContext.resultArea and (not fusionTabContext.tierCoreButton or fusionTabContext.tierCoreButton:isDestroyed()) then
         fusionTabContext.tierCoreButton = fusionTabContext.panel.fusionReduceButton
             or fusionTabContext.resultArea.fusionReduceButton
             or fusionTabContext.panel:recursiveGetChildById('fusionReduceButton')
+        fusionTabContext.tierCoreButtonBaseColor = nil
     end
 
     if fusionTabContext.resultArea and (not fusionTabContext.successRateLabel or fusionTabContext.successRateLabel:isDestroyed()) then
@@ -637,6 +641,8 @@ function forgeController:updateFusionCoreButtons()
         local tierBaseText = resolveBaseText(context.tierLossBaseText, tierLossLabel, '100%', false, lastTierSelection)
         context.successRateBaseText = successBaseText
         context.tierLossBaseText = tierBaseText
+        context.successCoreButtonBaseColor = nil
+        context.tierCoreButtonBaseColor = nil
         updateLabel(successRateLabel, successBaseText)
         updateLabel(tierLossLabel, tierBaseText)
         context.lastSuccessSelection = false
@@ -659,7 +665,7 @@ function forgeController:updateFusionCoreButtons()
         coreBalance = player:getResourceBalance(forgeResourceTypes.cores) or 0
     end
 
-    local function setButtonState(button, selected, enabled)
+    local function setButtonState(button, selected, enabled, baseColorField)
         if not button or button:isDestroyed() then
             return
         end
@@ -671,6 +677,19 @@ function forgeController:updateFusionCoreButtons()
         if button.setEnabled then
             button:setEnabled(enabled or selected)
         end
+
+        if button.setBackgroundColor then
+            local baseColor = context[baseColorField]
+            if not baseColor then
+                baseColor = button:getBackgroundColor()
+                context[baseColorField] = baseColor
+            end
+
+            local targetColor = selected and FUSION_CORE_ACTIVE_COLOR or baseColor
+            if targetColor then
+                button:setBackgroundColor(targetColor)
+            end
+        end
     end
 
     local successSelectedText = context.successRateSelectedText or '65%'
@@ -679,8 +698,8 @@ function forgeController:updateFusionCoreButtons()
     if coreBalance <= 0 then
         selections.success = false
         selections.tier = false
-        setButtonState(successButton, false, false)
-        setButtonState(tierButton, false, false)
+        setButtonState(successButton, false, false, 'successCoreButtonBaseColor')
+        setButtonState(tierButton, false, false, 'tierCoreButtonBaseColor')
         local successBaseText = resolveBaseText(context.successRateBaseText, successRateLabel, '50%', false,
             lastSuccessSelection)
         local tierBaseText = resolveBaseText(context.tierLossBaseText, tierLossLabel, '100%', false, lastTierSelection)
@@ -723,8 +742,8 @@ function forgeController:updateFusionCoreButtons()
         end
     end
 
-    setButtonState(successButton, selectedSuccess, successEnabled)
-    setButtonState(tierButton, selectedTier, tierEnabled)
+    setButtonState(successButton, selectedSuccess, successEnabled, 'successCoreButtonBaseColor')
+    setButtonState(tierButton, selectedTier, tierEnabled, 'tierCoreButtonBaseColor')
 
     local successBaseText = resolveBaseText(context.successRateBaseText, successRateLabel, '50%', selectedSuccess,
         lastSuccessSelection)

--- a/modules/game_forge/game_forge.lua
+++ b/modules/game_forge/game_forge.lua
@@ -640,6 +640,37 @@ function forgeController:updateFusionCoreButtons()
         end
     end
 
+    local function normalizeColorValue(colorValue)
+        if not colorValue then
+            return nil
+        end
+
+        local valueType = type(colorValue)
+        if valueType ~= 'string' then
+            local ok, converted = pcall(colortostring, colorValue)
+            if ok and type(converted) == 'string' then
+                colorValue = converted
+            else
+                colorValue = nil
+            end
+        end
+
+        if type(colorValue) == 'string' then
+            local normalized = colorValue:lower()
+            if normalized == '#ffffff' or normalized == '#ffffffff' or normalized == 'white' then
+                return nil
+            end
+
+            if #normalized == 9 then
+                return normalized:sub(1, 7)
+            end
+
+            return normalized
+        end
+
+        return nil
+    end
+
     local function applyLabelSelection(label, selected, baseColorField)
         if not label or label:isDestroyed() then
             context[baseColorField] = nil
@@ -651,28 +682,18 @@ function forgeController:updateFusionCoreButtons()
         end
 
         local baseColor = context[baseColorField]
-        if type(baseColor) == 'string' then
-            local normalized = baseColor:lower()
-            if normalized == '#ffffff' or normalized == 'white' then
-                baseColor = FUSION_CORE_DEFAULT_COLOR
-                context[baseColorField] = baseColor
-            end
-        end
-        if not baseColor then
-            baseColor = label:getColor()
-            if type(baseColor) == 'string' then
-                local normalized = baseColor:lower()
-                if normalized == '#ffffff' or normalized == 'white' then
-                    baseColor = nil
-                end
-            end
-            if not baseColor or baseColor == '' then
-                baseColor = FUSION_CORE_DEFAULT_COLOR
-            end
+        local normalizedBase = normalizeColorValue(baseColor)
+        if normalizedBase then
+            baseColor = normalizedBase
             context[baseColorField] = baseColor
         end
 
-        local targetColor = selected and FUSION_CORE_ACTIVE_COLOR or baseColor
+        if not baseColor then
+            baseColor = normalizeColorValue(label:getColor()) or FUSION_CORE_DEFAULT_COLOR
+            context[baseColorField] = baseColor
+        end
+
+        local targetColor = selected and FUSION_CORE_ACTIVE_COLOR or (normalizeColorValue(baseColor) or FUSION_CORE_DEFAULT_COLOR)
         if targetColor and label:getColor() ~= targetColor then
             label:setColor(targetColor)
         end

--- a/modules/game_forge/game_forge.lua
+++ b/modules/game_forge/game_forge.lua
@@ -383,12 +383,14 @@ local function resolveFusionTabContext()
         fusionTabContext.successRateLabel = fusionTabContext.panel.fusionSuccessRateValue
             or fusionTabContext.resultArea.fusionSuccessRateValue
             or fusionTabContext.panel:recursiveGetChildById('fusionSuccessRateValue')
+        fusionTabContext.successRateLabelBaseColor = nil
     end
 
     if fusionTabContext.resultArea and (not fusionTabContext.tierLossLabel or fusionTabContext.tierLossLabel:isDestroyed()) then
         fusionTabContext.tierLossLabel = fusionTabContext.panel.fusionTierLossValue
             or fusionTabContext.resultArea.fusionTierLossValue
             or fusionTabContext.panel:recursiveGetChildById('fusionTierLossValue')
+        fusionTabContext.tierLossLabelBaseColor = nil
     end
 
     if fusionTabContext.convergenceSection and (not fusionTabContext.convergenceItemsPanel or fusionTabContext.convergenceItemsPanel:isDestroyed()) then
@@ -582,12 +584,14 @@ function forgeController:updateFusionCoreButtons()
     if not successRateLabel or successRateLabel:isDestroyed() then
         successRateLabel = context.panel and context.panel:recursiveGetChildById('fusionSuccessRateValue')
         context.successRateLabel = successRateLabel
+        context.successRateLabelBaseColor = nil
     end
 
     local tierLossLabel = context.tierLossLabel
     if not tierLossLabel or tierLossLabel:isDestroyed() then
         tierLossLabel = context.panel and context.panel:recursiveGetChildById('fusionTierLossValue')
         context.tierLossLabel = tierLossLabel
+        context.tierLossLabelBaseColor = nil
     end
 
     local lastSuccessSelection = context.lastSuccessSelection and true or false
@@ -635,6 +639,28 @@ function forgeController:updateFusionCoreButtons()
         end
     end
 
+    local function applyLabelSelection(label, selected, baseColorField)
+        if not label or label:isDestroyed() then
+            context[baseColorField] = nil
+            return
+        end
+
+        if not label.setColor or not label.getColor then
+            return
+        end
+
+        local baseColor = context[baseColorField]
+        if not baseColor then
+            baseColor = label:getColor()
+            context[baseColorField] = baseColor
+        end
+
+        local targetColor = selected and FUSION_CORE_ACTIVE_COLOR or baseColor
+        if targetColor and label:getColor() ~= targetColor then
+            label:setColor(targetColor)
+        end
+    end
+
     if not successButton and not tierButton then
         local successBaseText = resolveBaseText(context.successRateBaseText, successRateLabel, '50%', false,
             lastSuccessSelection)
@@ -645,6 +671,8 @@ function forgeController:updateFusionCoreButtons()
         context.tierCoreButtonBaseColor = nil
         updateLabel(successRateLabel, successBaseText)
         updateLabel(tierLossLabel, tierBaseText)
+        applyLabelSelection(successRateLabel, false, 'successRateLabelBaseColor')
+        applyLabelSelection(tierLossLabel, false, 'tierLossLabelBaseColor')
         context.lastSuccessSelection = false
         context.lastTierSelection = false
         return
@@ -707,6 +735,8 @@ function forgeController:updateFusionCoreButtons()
         context.tierLossBaseText = tierBaseText
         updateLabel(successRateLabel, successBaseText)
         updateLabel(tierLossLabel, tierBaseText)
+        applyLabelSelection(successRateLabel, false, 'successRateLabelBaseColor')
+        applyLabelSelection(tierLossLabel, false, 'tierLossLabelBaseColor')
         context.lastSuccessSelection = false
         context.lastTierSelection = false
         return
@@ -754,6 +784,8 @@ function forgeController:updateFusionCoreButtons()
 
     updateLabel(successRateLabel, selectedSuccess and successSelectedText or successBaseText)
     updateLabel(tierLossLabel, selectedTier and tierSelectedText or tierBaseText)
+    applyLabelSelection(successRateLabel, selectedSuccess, 'successRateLabelBaseColor')
+    applyLabelSelection(tierLossLabel, selectedTier, 'tierLossLabelBaseColor')
 
     context.lastSuccessSelection = selectedSuccess
     context.lastTierSelection = selectedTier

--- a/modules/game_forge/tab/fusion/fusion.html
+++ b/modules/game_forge/tab/fusion/fusion.html
@@ -86,7 +86,14 @@
         <table class="fusion-stats">
           <tr>
             <td text="Success Rate:"></td>
-            <td id="fusionSuccessRateValue" text="50%"></td>
+            <td>
+              <label
+                id="fusionSuccessRateValue"
+                class="fusion-stat-value"
+                text="50%"
+                style="color: #d33c3c"
+              ></label>
+            </td>
           </tr>
           <tr>
             <td>
@@ -110,7 +117,14 @@
           </tr>
           <tr>
             <td text="Tier Loss:"></td>
-            <td id="fusionTierLossValue" text="100%"></td>
+            <td>
+              <label
+                id="fusionTierLossValue"
+                class="fusion-stat-value"
+                text="100%"
+                style="color: #d33c3c"
+              ></label>
+            </td>
           </tr>
           <tr>
             <td>

--- a/modules/game_forge/tab/fusion/fusion.html
+++ b/modules/game_forge/tab/fusion/fusion.html
@@ -91,9 +91,10 @@
           <tr>
             <td>
               <button
+                id="fusionImproveButton"
                 class="fusion-stat-button"
                 text="Improve to 65%"
-                disabled
+                onclick="self:onToggleFusionCore('success')"
               ></button>
             </td>
             <td>
@@ -114,9 +115,10 @@
           <tr>
             <td>
               <button
+                id="fusionReduceButton"
                 class="fusion-stat-button"
                 text="Reduce to 50%"
-                disabled
+                onclick="self:onToggleFusionCore('tier')"
               ></button>
             </td>
             <td>

--- a/modules/game_forge/tab/fusion/fusion.html
+++ b/modules/game_forge/tab/fusion/fusion.html
@@ -86,7 +86,7 @@
         <table class="fusion-stats">
           <tr>
             <td text="Success Rate:"></td>
-            <td text="50%"></td>
+            <td id="fusionSuccessRateValue" text="50%"></td>
           </tr>
           <tr>
             <td>
@@ -110,7 +110,7 @@
           </tr>
           <tr>
             <td text="Tier Loss:"></td>
-            <td text="100%"></td>
+            <td id="fusionTierLossValue" text="100%"></td>
           </tr>
           <tr>
             <td>


### PR DESCRIPTION
## Summary
- enable the fusion bonus buttons when the player has exalted cores available
- track fusion core selections and disallow choosing both bonuses with only one core remaining
- refresh button state whenever resources, selections, or panels change

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e035b7c120832ea398aeddacd48038