### PR TITLE
Improve forge controller initial state management

### DIFF
--- a/modules/game_forge/game_forge.lua
+++ b/modules/game_forge/game_forge.lua
@@ -978,7 +978,8 @@ end
 
 function forgeController:onInit()
     connect(g_game, {
-        onBrowseForgeHistory = onBrowseForgeHistory
+        onBrowseForgeHistory = onBrowseForgeHistory,
+        forgeData = forgeData,
     })
 
     if not forgeButton then
@@ -1119,7 +1120,6 @@ function onBrowseForgeHistory(page, lastPage, currentCount, historyList)
         historyPanel.historyPageLabel = pageLabel
     end
     if pageLabel then
-        g_logger.info(page .. "/" .. lastPage)
         pageLabel:setText(tr('Page %d/%d', page, lastPage))
     end
 
@@ -1144,7 +1144,8 @@ end
 
 function forgeController:onTerminate()
     disconnect(g_game, {
-        onBrowseForgeHistory = onBrowseForgeHistory
+        onBrowseForgeHistory = onBrowseForgeHistory,
+        forgeData = forgeData,
     })
 end
 
@@ -1323,6 +1324,7 @@ function forgeController:applyForgeConfiguration(config)
         local numericValue = tonumber(value)
         if numericValue then
             initial[key] = numericValue
+            g_logger.info("Setting initial value for " .. key .. " to " .. tostring(numericValue))
         end
     end
 
@@ -1344,7 +1346,7 @@ function g_game.onOpenForge(openData)
     forgeController:updateFusionItems()
 end
 
-function g_game.forgeData(config)
+function forgeData(config)
     forgeController:applyForgeConfiguration(config)
 end
 

--- a/modules/game_forge/game_forge_helpers.lua
+++ b/modules/game_forge/game_forge_helpers.lua
@@ -1,0 +1,245 @@
+local Helpers = {}
+
+function Helpers.cloneValue(value)
+    if type(value) == 'table' then
+        if table and type(table.recursivecopy) == 'function' then
+            return table.recursivecopy(value)
+        end
+
+        local copy = {}
+        for key, child in pairs(value) do
+            copy[key] = Helpers.cloneValue(child)
+        end
+        return copy
+    end
+
+    return value
+end
+
+function Helpers.normalizeTierPriceEntries(entries)
+    local prices = {}
+    if type(entries) ~= 'table' then
+        return prices
+    end
+
+    for _, entry in ipairs(entries) do
+        if type(entry) == 'table' then
+            local tierId = tonumber(entry.tier) or tonumber(entry.tierId) or tonumber(entry.id)
+            local price = tonumber(entry.price) or tonumber(entry.cost) or tonumber(entry.value)
+            if tierId then
+                prices[tierId + 1] = price or 0
+            end
+        end
+    end
+
+    return prices
+end
+
+function Helpers.normalizeClassPriceEntries(entries)
+    local pricesByClass = {}
+    if type(entries) ~= 'table' then
+        return pricesByClass
+    end
+
+    for _, classInfo in ipairs(entries) do
+        if type(classInfo) == 'table' then
+            local classId = tonumber(classInfo.classId)
+                or tonumber(classInfo.id)
+                or tonumber(classInfo.classification)
+            if classId then
+                pricesByClass[classId] = Helpers.normalizeTierPriceEntries(classInfo.tiers)
+            end
+        end
+    end
+
+    return pricesByClass
+end
+
+function Helpers.normalizeFusionGradeEntries(entries)
+    local values = {}
+    if type(entries) ~= 'table' then
+        return values
+    end
+
+    for _, entry in ipairs(entries) do
+        if type(entry) == 'table' then
+            local tierId = tonumber(entry.tier) or tonumber(entry.tierId) or tonumber(entry.id)
+            if tierId then
+                local value = tonumber(entry.exaltedCores)
+                    or tonumber(entry.cores)
+                    or tonumber(entry.value)
+                values[tierId + 1] = value or 0
+            end
+        end
+    end
+
+    return values
+end
+
+function Helpers.resolveForgePrice(priceMap, itemPtr, itemTier)
+    if type(priceMap) ~= 'table' then
+        return 0
+    end
+
+    local tierIndex = (tonumber(itemTier) or 0) + 1
+
+    local directValue = priceMap[tierIndex] or priceMap[tierIndex - 1]
+    if directValue ~= nil then
+        return tonumber(directValue) or 0
+    end
+
+    local classification = itemPtr and itemPtr.getClassification and itemPtr:getClassification()
+    if classification then
+        local classPrices = priceMap[classification] or priceMap[tostring(classification)]
+        if type(classPrices) ~= 'table' then
+            classPrices = priceMap[classification + 1]
+        end
+
+        if type(classPrices) == 'table' then
+            return tonumber(classPrices[tierIndex]) or tonumber(classPrices[tierIndex - 1]) or 0
+        end
+    end
+
+    return 0
+end
+
+function Helpers.defaultResourceFormatter(value)
+    local numericValue = tonumber(value) or 0
+    return tostring(numericValue)
+end
+
+function Helpers.formatGoldAmount(value)
+    local numericValue = tonumber(value) or 0
+    if type(comma_value) == 'function' then
+        return comma_value(tostring(numericValue))
+    end
+
+    return tostring(numericValue)
+end
+
+function Helpers.formatHistoryDate(timestamp)
+    if not timestamp or timestamp == 0 then
+        return tr('Unknown')
+    end
+
+    return os.date('%Y-%m-%d, %H:%M:%S', timestamp)
+end
+
+function Helpers.resolveHistoryList(panel)
+    if not panel then
+        return nil
+    end
+
+    if panel.historyList and not panel.historyList:isDestroyed() then
+        return panel.historyList
+    end
+
+    local list = panel:getChildById('historyList')
+    if list then
+        panel.historyList = list
+    end
+    return list
+end
+
+function Helpers.registerResourceConfig(resourceConfig, resourceType, config)
+    if not resourceConfig or not resourceType or resourceConfig[resourceType] == config then
+        return
+    end
+
+    resourceConfig[resourceType] = config
+end
+
+function Helpers.handleInitialValues(statusConfigs, resourceConfig)
+    if type(statusConfigs) ~= 'table' or type(resourceConfig) ~= 'table' then
+        return
+    end
+
+    for _, config in ipairs(statusConfigs) do
+        if config.resourceType then
+            Helpers.registerResourceConfig(resourceConfig, config.resourceType, config)
+        end
+
+        if config.eventResourceTypes then
+            for _, resourceType in ipairs(config.eventResourceTypes) do
+                Helpers.registerResourceConfig(resourceConfig, resourceType, config)
+            end
+        end
+    end
+end
+
+function Helpers.resolveStatusWidget(controller, config)
+    if config.widget then
+        if config.widget:isDestroyed() then
+            config.widget = nil
+        else
+            return config.widget
+        end
+    end
+
+    if not controller or not controller.ui then
+        return nil
+    end
+
+    local widget = controller:findWidget(config.selector)
+    if widget then
+        config.widget = widget
+    end
+
+    return widget
+end
+
+function Helpers.loadTabFragment(controller, tabName)
+    if not controller or not controller.ui then
+        return nil
+    end
+
+    local fragment = io.content(('modules/%s/tab/%s/%s.html'):format(controller.name, tabName, tabName))
+    local container = controller.ui.content:prepend(fragment)
+    local panel = container and container[tabName]
+    if panel and panel.hide then
+        panel:hide()
+    end
+    return panel
+end
+
+function Helpers.resolveScrollContents(widget)
+    if not widget or widget:isDestroyed() then
+        return nil
+    end
+
+    if widget.getChildById then
+        local contents = widget:getChildById('contentsPanel')
+        if contents and not contents:isDestroyed() then
+            return contents
+        end
+    end
+
+    return widget
+end
+
+function Helpers.getChildrenByStyleName(widget, styleName)
+    if not widget or widget:isDestroyed() then
+        return {}
+    end
+
+    local children = widget:recursiveGetChildrenByStyleName(styleName)
+    if type(children) ~= 'table' then
+        return {}
+    end
+
+    local results = {}
+    for _, child in ipairs(children) do
+        if child and not child:isDestroyed() then
+            table.insert(results, child)
+        end
+    end
+
+    return results
+end
+
+function Helpers.getFirstChildByStyleName(widget, styleName)
+    local children = Helpers.getChildrenByStyleName(widget, styleName)
+    return children[1]
+end
+
+return Helpers

--- a/modules/game_forge/tab/conversion/conversion.html
+++ b/modules/game_forge/tab/conversion/conversion.html
@@ -98,6 +98,7 @@
         ></UIItem>
       </UIButton>
       <label
+        id="forgeIncreaseDustCurrentLevel"
         class="conversion-note--inline"
         text="Raise limit from 100"
         style="position: relative; left: 15px; margin-top: 15"
@@ -108,7 +109,12 @@
           style="margin-left: 15px"
           src="images/icon-currency-dust"
         />
-        <label class="conversion-note--inline" text="to 101"></label>
+
+        <label
+          id="forgeIncreaseDustNextLevel"
+          class="conversion-note--inline"
+          text="to 101"
+        ></label>
         <img class="conversion-output-item" src="images/icon-currency-dust" />
       </div>
     </div>

--- a/modules/game_forge/tab/conversion/conversion.lua
+++ b/modules/game_forge/tab/conversion/conversion.lua
@@ -1,5 +1,207 @@
--- Todo 
+-- Todo
 -- change to TypeScript
-function showConversion()
-  return forgeController:loadTab('conversion')
+
+local ConversionTab = {}
+
+local function resolveConversionDependencies(controller, dependencies)
+    dependencies = dependencies or {}
+
+    if not dependencies.resourceTypes then
+        dependencies.resourceTypes = controller and controller.conversionResourceTypes or nil
+    end
+
+    if not dependencies.actions then
+        dependencies.actions = controller and controller.conversionActions or nil
+    end
+
+    return dependencies
 end
+
+function ConversionTab.formatDustAmount(controller, value)
+    local numericValue = tonumber(value) or 0
+    local maxDust = 100
+
+    if controller then
+        maxDust = tonumber(controller.maxDustLevel)
+            or tonumber(controller.currentDustLevel)
+            or maxDust
+    end
+
+    if not maxDust or maxDust <= 0 then
+        return tostring(numericValue)
+    end
+
+    g_logger.info(">>" .. string.format('%d/%d', numericValue, maxDust))
+    return string.format('%d/%d', numericValue, maxDust)
+end
+
+function ConversionTab.updateDustLevelLabel(controller, panel, dustLevel, dependencies)
+    dependencies = resolveConversionDependencies(controller, dependencies)
+    panel = panel or (ui.panels and ui.panels['conversion'])
+    if not panel or panel:isDestroyed() then
+        return
+    end
+
+    g_logger.info(">>>>updateDustLevelLabel")
+
+    local dustLevelLabel = panel:recursiveGetChildById('forgeDustLevel')
+    if not dustLevelLabel or dustLevelLabel:isDestroyed() then
+        return
+    end
+
+    local dustLevelValue = dustLevel or tonumber(controller.currentDustLevel)
+        or tonumber(controller.maxDustLevel) or 0
+    local displayedDustLevel = math.max(dustLevelValue - 75, 0)
+    dustLevelLabel:setText(tostring(displayedDustLevel))
+    g_logger.info("displayedDustLevel > " .. displayedDustLevel)
+
+    local forgeIncreaseDustCurrentLevelLabel = panel:recursiveGetChildById('forgeIncreaseDustCurrentLevel')
+    if forgeIncreaseDustCurrentLevelLabel and not forgeIncreaseDustCurrentLevelLabel:isDestroyed() then
+        forgeIncreaseDustCurrentLevelLabel:setText(("Raise limit from %d"):format(dustLevelValue))
+
+        g_logger.info("forgeIncreaseDustCurrentLevelLabel > " .. dustLevelValue)
+    end
+    local forgeIncreaseDustNextLevelLabel = panel:recursiveGetChildById('forgeIncreaseDustNextLevel')
+    if forgeIncreaseDustNextLevelLabel and not forgeIncreaseDustNextLevelLabel:isDestroyed() then
+        forgeIncreaseDustNextLevelLabel:setText(("to %d"):format(dustLevelValue + 1))
+        g_logger.info("forgeIncreaseDustNextLevelLabel > " .. dustLevelValue + 1)
+    end
+
+end
+
+function ConversionTab.onConversion(controller, conversionType, dependencies)
+    if not controller or not controller.ui then
+        return
+    end
+
+    local player = g_game.getLocalPlayer()
+    if not player then
+        return
+    end
+
+    dependencies = resolveConversionDependencies(controller, dependencies)
+    local resourceTypes = dependencies.resourceTypes or {}
+    local actions = dependencies.actions or {}
+
+    local function finalizeConversion()
+        controller:updateFusionCoreButtons()
+        controller:updateResourceBalances(resourceTypes.dust)
+        controller:updateDustLevelLabel()
+    end
+
+    if conversionType == actions.DUST2SLIVER then
+        local dustType = resourceTypes.dust
+        local dustBalance = dustType and player:getResourceBalance(dustType) or 0
+        if dustBalance <= 60 then
+            return
+        end
+        g_game.forgeRequest(conversionType)
+        finalizeConversion()
+        return
+    end
+
+    if conversionType == actions.SLIVER2CORE then
+        local sliverType = resourceTypes.sliver
+        local sliverBalance = sliverType and player:getResourceBalance(sliverType) or 0
+        if sliverBalance <= 50 then
+            return
+        end
+        g_game.forgeRequest(conversionType)
+        finalizeConversion()
+        return
+    end
+
+    if conversionType == actions.INCREASELIMIT then
+        local dustType = resourceTypes.dust
+        local dustBalance = dustType and player:getResourceBalance(dustType) or 0
+        local maxDustLevel = tonumber(controller.currentDustLevel)
+            or tonumber(controller.maxDustLevel) or 0
+        local currentNecessaryDust = maxDustLevel - 75
+        local maxDustCap = tonumber(controller.maxDustCap) or 0
+
+        if maxDustCap > 0 and maxDustLevel >= maxDustCap then
+            return
+        end
+
+        if dustBalance < currentNecessaryDust then
+            return
+        end
+        g_game.forgeRequest(conversionType)
+
+        local newDustLevel = maxDustLevel + 1
+        if maxDustCap > 0 then
+            newDustLevel = math.min(newDustLevel, maxDustCap)
+        end
+
+        controller.currentDustLevel = newDustLevel
+        if not controller.maxDustLevel or controller.maxDustLevel < newDustLevel then
+            controller.maxDustLevel = newDustLevel
+        end
+
+        finalizeConversion()
+        return
+    end
+
+    finalizeConversion()
+end
+
+function ConversionTab.onTabLoaded(controller, tabName, panel)
+    if tabName ~= 'conversion' then
+        return
+    end
+
+    ConversionTab.updateDustLevelLabel(controller, panel)
+end
+
+function ConversionTab.applyInitialValues(controller, openData)
+    local maxDustLevel = tonumber(openData.maxDustLevel)
+        or tonumber(openData.maxDust)
+        or tonumber(openData.dustLevel)
+
+    g_logger.info("maxDustLevel: " .. tostring(maxDustLevel))
+
+    if maxDustLevel and maxDustLevel >= 0 then
+        controller.maxDustLevel = maxDustLevel
+    end
+
+    local currentDustLevel = tonumber(openData.currentDustLevel)
+        or tonumber(openData.dustLevel)
+
+    if currentDustLevel and currentDustLevel >= 0 then
+        controller.currentDustLevel = currentDustLevel
+    end
+
+    local maxDustCap = tonumber(openData.maxDustCap)
+    if maxDustCap and maxDustCap >= 0 then
+        controller.maxDustCap = maxDustCap
+    end
+
+    if (not controller.maxDustLevel or controller.maxDustLevel <= 0) and controller.currentDustLevel then
+        controller.maxDustLevel = controller.currentDustLevel
+    end
+
+    if (not controller.currentDustLevel or controller.currentDustLevel <= 0) and controller.maxDustLevel then
+        controller.currentDustLevel = controller.maxDustLevel
+    end
+
+    ConversionTab.updateDustLevelLabel(controller, ui.panels and ui.panels['conversion'], maxDustLevel)
+end
+
+function ConversionTab.onOpenForge(controller)
+    ConversionTab.updateDustLevelLabel(controller, ui.panels and ui.panels['conversion'])
+end
+
+function ConversionTab.registerDependencies(controller, dependencies)
+    dependencies = resolveConversionDependencies(controller, dependencies)
+
+    if controller then
+        controller.conversionResourceTypes = dependencies.resourceTypes
+        controller.conversionActions = dependencies.actions
+    end
+end
+
+function showConversion()
+    return forgeController:loadTab('conversion')
+end
+
+return ConversionTab

--- a/src/client/game.h
+++ b/src/client/game.h
@@ -581,6 +581,46 @@ struct ForgeTransferData
     std::vector<ForgeItemInfo> receivers;
 };
 
+struct ForgeTierPrice
+{
+    uint8_t tier{ 0 };
+    uint64_t price{ 0 };
+};
+
+struct ForgeGradeData
+{
+    uint8_t tier{ 0 };
+    uint8_t exaltedCores{ 0 };
+};
+
+struct ForgeClassTierPrices
+{
+    uint8_t classId{ 0 };
+    std::vector<ForgeTierPrice> tiers;
+};
+
+struct ForgeConfigData
+{
+    std::vector<ForgeClassTierPrices> classPrices;
+    std::vector<ForgeGradeData> fusionGrades;
+    std::vector<ForgeTierPrice> convergenceFusionPrices;
+    std::vector<ForgeTierPrice> convergenceTransferPrices;
+    uint8_t dustPercent{ 0 };
+    uint8_t dustToSliver{ 0 };
+    uint8_t sliverToCore{ 0 };
+    uint8_t dustPercentUpgrade{ 0 };
+    uint16_t maxDustLevel{ 0 };
+    uint16_t maxDustCap{ 0 };
+    uint8_t normalDustFusion{ 0 };
+    uint8_t convergenceDustFusion{ 0 };
+    uint8_t normalDustTransfer{ 0 };
+    uint8_t convergenceDustTransfer{ 0 };
+    uint8_t fusionChanceBase{ 0 };
+    uint8_t fusionChanceImproved{ 0 };
+    uint8_t fusionReduceTierLoss{ 0 };
+    bool hasConvergence{ false };
+};
+
 struct ForgeOpenData
 {
     std::vector<ForgeItemInfo> fusionItems;

--- a/src/client/luavaluecasts_client.cpp
+++ b/src/client/luavaluecasts_client.cpp
@@ -1557,6 +1557,38 @@ int push_luavalue(const ForgeItemInfo& item) {
     return 1;
 }
 
+int push_luavalue(const ForgeTierPrice& data) {
+    g_lua.createTable(0, 2);
+    g_lua.pushInteger(data.tier);
+    g_lua.setField("tier");
+    g_lua.pushInteger(data.price);
+    g_lua.setField("price");
+    return 1;
+}
+
+int push_luavalue(const ForgeGradeData& data) {
+    g_lua.createTable(0, 2);
+    g_lua.pushInteger(data.tier);
+    g_lua.setField("tier");
+    g_lua.pushInteger(data.exaltedCores);
+    g_lua.setField("exaltedCores");
+    return 1;
+}
+
+int push_luavalue(const ForgeClassTierPrices& data) {
+    g_lua.createTable(0, 2);
+    g_lua.pushInteger(data.classId);
+    g_lua.setField("classId");
+
+    g_lua.createTable(data.tiers.size(), 0);
+    for (size_t i = 0; i < data.tiers.size(); ++i) {
+        push_luavalue(data.tiers[i]);
+        g_lua.rawSeti(i + 1);
+    }
+    g_lua.setField("tiers");
+    return 1;
+}
+
 int push_luavalue(const ForgeTransferData& data) {
     g_lua.createTable(0, 2);
     g_lua.createTable(data.donors.size(), 0);
@@ -1612,5 +1644,85 @@ int push_luavalue(const ForgeOpenData& data) {
 
     g_lua.pushInteger(data.dustLevel);
     g_lua.setField("dustLevel");
+    return 1;
+}
+
+int push_luavalue(const ForgeConfigData& data) {
+    g_lua.createTable(0, 14);
+
+    g_lua.createTable(data.classPrices.size(), 0);
+    for (size_t i = 0; i < data.classPrices.size(); ++i) {
+        push_luavalue(data.classPrices[i]);
+        g_lua.rawSeti(i + 1);
+    }
+    g_lua.setField("classPrices");
+
+    g_lua.createTable(data.fusionGrades.size(), 0);
+    for (size_t i = 0; i < data.fusionGrades.size(); ++i) {
+        push_luavalue(data.fusionGrades[i]);
+        g_lua.rawSeti(i + 1);
+    }
+    g_lua.setField("fusionGrades");
+
+    g_lua.createTable(data.convergenceFusionPrices.size(), 0);
+    for (size_t i = 0; i < data.convergenceFusionPrices.size(); ++i) {
+        push_luavalue(data.convergenceFusionPrices[i]);
+        g_lua.rawSeti(i + 1);
+    }
+    g_lua.setField("convergenceFusionPrices");
+
+    g_lua.createTable(data.convergenceTransferPrices.size(), 0);
+    for (size_t i = 0; i < data.convergenceTransferPrices.size(); ++i) {
+        push_luavalue(data.convergenceTransferPrices[i]);
+        g_lua.rawSeti(i + 1);
+    }
+    g_lua.setField("convergenceTransferPrices");
+
+    g_lua.pushInteger(data.dustPercent);
+    g_lua.setField("dustPercent");
+
+    g_lua.pushInteger(data.dustToSliver);
+    g_lua.setField("dustToSliver");
+
+    g_lua.pushInteger(data.sliverToCore);
+    g_lua.setField("sliverToCore");
+
+    g_lua.pushInteger(data.dustPercentUpgrade);
+    g_lua.setField("dustPercentUpgrade");
+
+    g_lua.pushInteger(data.maxDustLevel);
+    g_lua.setField("maxDustLevel");
+
+    g_lua.pushInteger(data.maxDustCap);
+    g_lua.setField("maxDustCap");
+
+    g_lua.pushInteger(data.normalDustFusion);
+    g_lua.setField("normalDustFusion");
+
+    if (data.hasConvergence) {
+        g_lua.pushInteger(data.convergenceDustFusion);
+        g_lua.setField("convergenceDustFusion");
+    }
+
+    g_lua.pushInteger(data.normalDustTransfer);
+    g_lua.setField("normalDustTransfer");
+
+    if (data.hasConvergence) {
+        g_lua.pushInteger(data.convergenceDustTransfer);
+        g_lua.setField("convergenceDustTransfer");
+    }
+
+    g_lua.pushInteger(data.fusionChanceBase);
+    g_lua.setField("fusionChanceBase");
+
+    g_lua.pushInteger(data.fusionChanceImproved);
+    g_lua.setField("fusionChanceImproved");
+
+    g_lua.pushInteger(data.fusionReduceTierLoss);
+    g_lua.setField("fusionReduceTierLoss");
+
+    g_lua.pushBoolean(data.hasConvergence);
+    g_lua.setField("hasConvergence");
+
     return 1;
 }

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -26,7 +26,7 @@
 #include "framework/net/inputmessage.h"
 
 #include "attachedeffectmanager.h"
-#include "game.h"
+
 #include "item.h"
 #include "localplayer.h"
 #include "luavaluecasts_client.h"
@@ -1928,7 +1928,7 @@ void ProtocolGame::parseItemClasses(const InputMessagePtr& msg)
         forgeConfig.fusionChanceImproved = msg->getU8();
         forgeConfig.fusionReduceTierLoss = msg->getU8();
 
-        g_lua.callGlobalField("g_game", "forgeData", forgeConfig);
+
     } else {
         uint8_t totalForgeValues = 11;
         if (g_game.getClientVersion() >= 1316) {
@@ -1942,11 +1942,9 @@ void ProtocolGame::parseItemClasses(const InputMessagePtr& msg)
         for (auto i = 0; i < totalForgeValues; ++i) {
             msg->getU8(); // Forge values
         }
-
-        if (!forgeConfig.classPrices.empty()) {
-            g_lua.callGlobalField("g_game", "forgeData", forgeConfig);
-        }
     }
+
+    g_lua.callGlobalField("g_game", "forgeData", forgeConfig);
 }
 
 void ProtocolGame::parseCreatureMark(const InputMessagePtr& msg)


### PR DESCRIPTION
## Summary
- add a helper to deep copy forge data and persist the server provided configuration
- capture initial forge values (dust limits, pricing and chance fields) when the window opens
- update dust formatting and labels to rely on the stored player/server values

## Testing
- `luac -p modules/game_forge/game_forge.lua` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e156fbb56c832eaabcf9cd29c43f6e