### PR TITLE
Simplify fusion tab reactive updates

### DIFF
--- a/modules/game_forge/tab/fusion/fusion.html
+++ b/modules/game_forge/tab/fusion/fusion.html
@@ -67,8 +67,7 @@
             <label
               id="fusionSelectedItemCounter"
               class="forge-full-width-label"
-              text="0 / 1"
-            ></label>
+            >{{self.fusionSelectedItemCounterText}}</label>
           </div>
         </div>
 
@@ -81,7 +80,7 @@
             ></UIItem>
           </div>
           <div class="forge-counter">
-            <label class="forge-full-width-label" text="100"></label>
+            <label class="forge-full-width-label">{{self.fusionDustRequirementText}}</label>
             <img class="resource-icon" src="images/icon-currency-dust" />
           </div>
         </div>
@@ -89,7 +88,7 @@
         <table class="fusion-stats">
           <tr>
             <td text="Success Rate:"></td>
-            <td id="fusionSuccessRateValue" text="50%"></td>
+            <td id="fusionSuccessRateValue">{{self.fusionSuccessRateValue}}</td>
           </tr>
           <tr>
             <td>
@@ -113,7 +112,7 @@
           </tr>
           <tr>
             <td text="Tier Loss:"></td>
-            <td id="fusionTierLossValue" text="100%"></td>
+            <td id="fusionTierLossValue">{{self.fusionTierLossValue}}</td>
           </tr>
           <tr>
             <td>
@@ -154,7 +153,7 @@
             <UIItem class="forge-item-icon" style="item-id: 37160"></UIItem>
           </div>
           <div class="forge-counter">
-            <label class="forge-full-width-label" text="130"></label>
+            <label class="forge-full-width-label">{{self.fusionDustRequirementText}}</label>
           </div>
         </div>
       </div>
@@ -180,8 +179,7 @@
           <label
             id="fusionResultCostLabel"
             class="forge-full-width-label"
-            text="???"
-          ></label>
+          >{{self.fusionPriceDisplay}}</label>
           <img class="resource-icon" src="/images/game/prey/prey_gold" />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- update forge fusion tab flows to drive HTML bindings via controller properties instead of widget lookups
- keep fusion core base and selected values in controller state so rate and tier labels react without setText
- reset and configure conversion UI using property assignments for dust, price, and counters

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1a1a6dee4832eac03b952a7157561