### PR TITLE
Add support for locking client input to a widget

### DIFF
--- a/modules/game_wheel_html/game_wheel.lua
+++ b/modules/game_wheel_html/game_wheel.lua
@@ -444,6 +444,8 @@ function WheelController:show(skipRequest)
     self.ui:raise()
     self.ui:focus()
 
+    g_client.setLockWidget(self.ui)
+
     if WheelButton then
         WheelButton:setOn(true)
     end
@@ -469,6 +471,10 @@ function WheelController:hide()
     resetValues()
     if not self.ui then
         return
+    end
+
+    if g_client.getLockWidget() == self.ui then
+        g_client.setLockWidget(nil)
     end
 
     self.ui:hide()

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -46,6 +46,9 @@ public:
     void doMapScreenshot(std::string fileName) override;
 
     UIMapPtr getMapWidget() { return m_mapWidget; }
+    UIWidgetPtr getLockWidget() const { return m_lockWidget; }
+
+    void setLockWidget(const UIWidgetPtr& widget);
 
     float getEffectAlpha() const { return m_effectAlpha; }
     void setEffectAlpha(const float v) { m_effectAlpha = v; }
@@ -55,6 +58,7 @@ public:
 
 private:
     UIMapPtr m_mapWidget;
+    UIWidgetPtr m_lockWidget;
     float m_effectAlpha{ 1.f };
     float m_missileAlpha{ 1.f };
 };

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -46,7 +46,7 @@ public:
     void doMapScreenshot(std::string fileName) override;
 
     UIMapPtr getMapWidget() { return m_mapWidget; }
-    UIWidgetPtr getLockWidget() const { return m_lockWidget; }
+    UIWidgetPtr getLockWidget() { return m_lockWidget; }
 
     void setLockWidget(const UIWidgetPtr& widget);
 

--- a/src/client/luafunctions.cpp
+++ b/src/client/luafunctions.cpp
@@ -413,6 +413,8 @@ void Client::registerLuaFunctions()
     g_lua.bindSingletonFunction("g_gameConfig", "getWidgetTextFontName", &GameConfig::getWidgetTextFontName, &g_gameConfig);
 
     g_lua.registerSingletonClass("g_client");
+    g_lua.bindSingletonFunction("g_client", "getLockWidget", &Client::getLockWidget, &g_client);
+    g_lua.bindSingletonFunction("g_client", "setLockWidget", &Client::setLockWidget, &g_client);
     g_lua.bindSingletonFunction("g_client", "setEffectAlpha", &Client::setEffectAlpha, &g_client);
     g_lua.bindSingletonFunction("g_client", "setMissileAlpha", &Client::setMissileAlpha, &g_client);
 


### PR DESCRIPTION
## Summary
- add the ability for the client to lock input handling to a specific UI widget and clear it on termination
- expose the new widget locking helpers to Lua so scripts can set or query the lock

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6900eff06a5c832e84f0a501919cd2a3